### PR TITLE
면접 질문 사용자 별 순차 전송에 주말 미발송을 대응한다.

### DIFF
--- a/src/main/java/maeilmail/subscribe/core/Subscribe.java
+++ b/src/main/java/maeilmail/subscribe/core/Subscribe.java
@@ -31,8 +31,12 @@ public class Subscribe extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private QuestionCategory category;
 
+    @Column(nullable = false)
+    private Long nextQuestionSequence;
+
     public Subscribe(String email, QuestionCategory category) {
         this.email = email;
         this.category = category;
+        this.nextQuestionSequence = 0L;
     }
 }

--- a/src/main/java/maeilmail/subscribe/core/policy/PersonalSequenceChoicePolicy.java
+++ b/src/main/java/maeilmail/subscribe/core/policy/PersonalSequenceChoicePolicy.java
@@ -11,10 +11,8 @@ import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
 import maeilmail.subscribe.core.ChoiceQuestionPolicy;
 import maeilmail.subscribe.core.Subscribe;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-@Primary
 @Component
 @RequiredArgsConstructor
 class PersonalSequenceChoicePolicy implements ChoiceQuestionPolicy {

--- a/src/main/java/maeilmail/subscribe/core/policy/WeekdaysPersonalSequenceChoicePolicy.java
+++ b/src/main/java/maeilmail/subscribe/core/policy/WeekdaysPersonalSequenceChoicePolicy.java
@@ -22,7 +22,7 @@ class WeekdaysPersonalSequenceChoicePolicy implements ChoiceQuestionPolicy {
         List<QuestionSummary> questions = findQuestions(subscribe);
         Long nextQuestionSequence = subscribe.getNextQuestionSequence();
 
-        return questions.get(nextQuestionSequence.intValue());
+        return questions.get(nextQuestionSequence.intValue() % questions.size());
     }
 
     private List<QuestionSummary> findQuestions(Subscribe subscribe) {

--- a/src/main/java/maeilmail/subscribe/core/policy/WeekdaysPersonalSequenceChoicePolicy.java
+++ b/src/main/java/maeilmail/subscribe/core/policy/WeekdaysPersonalSequenceChoicePolicy.java
@@ -1,0 +1,40 @@
+package maeilmail.subscribe.core.policy;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import maeilmail.question.QuestionQueryService;
+import maeilmail.question.QuestionSummary;
+import maeilmail.subscribe.core.ChoiceQuestionPolicy;
+import maeilmail.subscribe.core.Subscribe;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component
+@RequiredArgsConstructor
+class WeekdaysPersonalSequenceChoicePolicy implements ChoiceQuestionPolicy {
+
+    private final QuestionQueryService questionQueryService;
+
+    @Override
+    public QuestionSummary choice(Subscribe subscribe, LocalDate ignore) {
+        List<QuestionSummary> questions = findQuestions(subscribe);
+        Long nextQuestionSequence = subscribe.getNextQuestionSequence();
+
+        return questions.get(nextQuestionSequence.intValue());
+    }
+
+    private List<QuestionSummary> findQuestions(Subscribe subscribe) {
+        List<QuestionSummary> questions = questionQueryService.queryAllByCategory(subscribe.getCategory().name());
+        validateQuestionEmpty(questions);
+
+        return questions;
+    }
+
+    private void validateQuestionEmpty(List<QuestionSummary> questions) {
+        if (questions.isEmpty()) {
+            throw new IllegalStateException("질문지를 결정할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -12,11 +12,12 @@ create table question
 
 create table subscribe
 (
-    id         bigint auto_increment,
-    email      varchar(255) not null,
-    category   enum ('BACKEND','FRONTEND') not null,
-    created_at timestamp(6),
-    updated_at timestamp(6),
+    id                     bigint auto_increment,
+    email                  varchar(255) not null,
+    category               enum ('BACKEND','FRONTEND') not null,
+    created_at             timestamp(6),
+    updated_at             timestamp(6),
+    next_question_sequence bigint       not null default '0',
     primary key (id)
 );
 


### PR DESCRIPTION
- close #73 
- sequence 컬럼을 추가하는것이 73번 이슈에 적혀있는 방안의 복잡도보다 저렴하다고 판단
    - 복잡도로 치루는 비용  : 신규 사용자 적응 문제, 연휴가 미포함되도록 변경된다면?  
    - 컬럼 추가로 치루는 비용 : update 비용, 컬럼 데이터 저장 공간
- next_question_sequence 컬럼을 추가하도록 변경
- update 쿼리는 벌크 update를 사용하도록 해야한다. -> #74
- edge case -> 7시 0분 32초에 가입했지만, 메일이 발송됐고.. sequence 증가가 안되면? -> 중복 메일 발송