### PR TITLE
질문 메일 발송 스케줄 로직에서 사용하는 쿼리에 create_at이 null인 구독자도 조회하도록 한다. 

### DIFF
--- a/src/main/java/maeilmail/subscribe/core/SendQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribe/core/SendQuestionScheduler.java
@@ -30,7 +30,7 @@ class SendQuestionScheduler {
     public void sendMail() {
         log.info("메일 전송을 시작합니다.");
         LocalDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
-        List<Subscribe> subscribes = subscribeRepository.findAllByCreatedAtBefore(now);
+        List<Subscribe> subscribes = subscribeRepository.findAllByCreatedAtBeforeOrCreatedAtIsNull(now);
         log.info("{}명의 사용자에게 메일을 전송합니다.", subscribes.size());
 
         subscribes.stream()

--- a/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
+++ b/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
@@ -16,5 +16,5 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
     @Query("select distinct s.email from Subscribe s where s.createdAt between :startOfDay and :endOfDay")
     List<String> findDistinctEmailsByCreatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 
-    List<Subscribe> findAllByCreatedAtBefore(LocalDateTime now);
+    List<Subscribe> findAllByCreatedAtBeforeOrCreatedAtIsNull(LocalDateTime baseDateTime);
 }


### PR DESCRIPTION
- close #82 

```sql
select
        s1_0.id,
        s1_0.category,
        s1_0.created_at,
        s1_0.email,
        s1_0.next_question_sequence,
        s1_0.updated_at 
    from
        subscribe s1_0 
    where
        s1_0.created_at<? 
        or s1_0.created_at is null
```