### PR TITLE
구독자의 nextQuestionSequence값을 증가시킨다.

### DIFF
--- a/src/main/java/maeilmail/admin/AdminReportScheduler.java
+++ b/src/main/java/maeilmail/admin/AdminReportScheduler.java
@@ -25,7 +25,7 @@ class AdminReportScheduler {
     private final DistributedSupport distributedSupport;
     private final StatisticsService statisticsService;
 
-    @Scheduled(cron = "0 30 7 1/1 * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 30 7 * * MON-FRI", zone = "Asia/Seoul")
     public void sendReport() {
         log.info("관리자 결과 전송, date = {}", LocalDate.now());
         EventReport report = statisticsService.generateDailyMailEventReport("question");

--- a/src/main/java/maeilmail/mail/MailSender.java
+++ b/src/main/java/maeilmail/mail/MailSender.java
@@ -29,11 +29,11 @@ public class MailSender {
             javaMailSender.send(mimeMessage);
             mailEventRepository.save(MailEvent.success(message.to(), message.type()));
         } catch (MessagingException | MailException e) {
-            mailEventRepository.save(MailEvent.fail(message.to(), message.type()));
             log.error("메일 전송 실패: email = {}, type = {}, 오류 = {}", message.to(), message.type(), e.getMessage(), e);
-        } catch (Exception e) {
             mailEventRepository.save(MailEvent.fail(message.to(), message.type()));
+        } catch (Exception e) {
             log.error("예기치 않은 오류 발생: email = {}, type = {}, 오류 = {}", message.to(), message.type(), e.getMessage(), e);
+            mailEventRepository.save(MailEvent.fail(message.to(), message.type()));
         } finally {
             try {
                 Thread.sleep(MAIL_SENDER_RATE_MILLISECONDS);

--- a/src/main/java/maeilmail/subscribe/core/SendQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribe/core/SendQuestionScheduler.java
@@ -2,7 +2,6 @@ package maeilmail.subscribe.core;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -17,7 +16,6 @@ import maeilmail.question.QuestionCategory;
 import maeilmail.question.QuestionSummary;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -44,13 +42,6 @@ class SendQuestionScheduler {
                 .map(this::choiceQuestion)
                 .filter(Objects::nonNull)
                 .forEach(mailSender::sendMail);
-    }
-
-    @Transactional
-    @Scheduled(cron = "0 0 22 * * MON-FRI")
-    public void increaseNextQuestionSequence() {
-        LocalDateTime baseDateTime = ZonedDateTime.of(LocalDate.now(), LocalTime.of(7, 0), KOREA_ZONE).toLocalDateTime();
-        subscribeRepository.increaseNextQuestionSequence(baseDateTime);
     }
 
     private MailMessage choiceQuestion(Subscribe subscribe) {

--- a/src/main/java/maeilmail/subscribe/core/SendQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribe/core/SendQuestionScheduler.java
@@ -32,7 +32,7 @@ class SendQuestionScheduler {
     private final SubscribeRepository subscribeRepository;
     private final DistributedSupport distributedSupport;
 
-    @Scheduled(cron = "0 0 7 * * MON-FRI")
+    @Scheduled(cron = "0 0 7 * * MON-FRI", zone = "Asia/Seoul")
     public void sendMail() {
         log.info("메일 전송을 시작합니다.");
         LocalDateTime now = ZonedDateTime.now(KOREA_ZONE).toLocalDateTime();

--- a/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
+++ b/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
@@ -20,6 +20,10 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
     List<Subscribe> findAllByCreatedAtBefore(LocalDateTime baseDateTime);
 
     @Modifying
-    @Query("update Subscribe s set s.nextQuestionSequence = s.nextQuestionSequence + 1 where s.createdAt < :baseDateTime")
+    @Query("""
+            update Subscribe s
+            set s.nextQuestionSequence = s.nextQuestionSequence + 1
+            where s.createdAt < :baseDateTime
+            """)
     void increaseNextQuestionSequence(LocalDateTime baseDateTime);
 }

--- a/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
+++ b/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import maeilmail.question.QuestionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
@@ -16,5 +17,9 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
     @Query("select distinct s.email from Subscribe s where s.createdAt between :startOfDay and :endOfDay")
     List<String> findDistinctEmailsByCreatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 
-    List<Subscribe> findAllByCreatedAtBeforeOrCreatedAtIsNull(LocalDateTime baseDateTime);
+    List<Subscribe> findAllByCreatedAtBefore(LocalDateTime baseDateTime);
+
+    @Modifying
+    @Query("update Subscribe s set s.nextQuestionSequence = s.nextQuestionSequence + 1 where s.createdAt < :baseDateTime")
+    void increaseNextQuestionSequence(LocalDateTime baseDateTime);
 }

--- a/src/main/java/maeilmail/subscribe/core/SubscribeSequenceScheduler.java
+++ b/src/main/java/maeilmail/subscribe/core/SubscribeSequenceScheduler.java
@@ -1,0 +1,29 @@
+package maeilmail.subscribe.core;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscribeSequenceScheduler {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final SubscribeRepository subscribeRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 22 * * MON-FRI", zone = "Asia/Seoul")
+    public void increaseNextQuestionSequence() {
+        LocalDateTime baseDateTime = ZonedDateTime.of(LocalDate.now(), LocalTime.of(7, 0), KOREA_ZONE).toLocalDateTime();
+        subscribeRepository.increaseNextQuestionSequence(baseDateTime);
+    }
+}

--- a/src/test/java/maeilmail/admin/AdminReportSchedulerTest.java
+++ b/src/test/java/maeilmail/admin/AdminReportSchedulerTest.java
@@ -1,0 +1,36 @@
+package maeilmail.admin;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import maeilmail.support.SchedulerTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminReportSchedulerTest {
+
+    @Test
+    @DisplayName("매주 월요일부터 금요일까지 평일에 한해서 매일 아침 7시 30분에 관리자 리포트 스케줄러가 동작하는지 확인한다.")
+    void sendReportCronWeekday() {
+        LocalDateTime initialTime = LocalDateTime.of(2024, 8, 26, 7, 30); // 월요일
+        List<LocalDateTime> expectedTimes = List.of(
+                LocalDateTime.of(2024, 8, 27, 7, 30),  // 화요일
+                LocalDateTime.of(2024, 8, 28, 7, 30),  // 수요일
+                LocalDateTime.of(2024, 8, 29, 7, 30),  // 목요일
+                LocalDateTime.of(2024, 8, 30, 7, 30),  // 금요일
+                LocalDateTime.of(2024, 9, 2, 7, 30),   // 다음 주 월요일
+                LocalDateTime.of(2024, 9, 3, 7, 30)    // 다음 주 화요일
+        );
+        SchedulerTestUtils.assertCronExpression(
+                AdminReportScheduler.class,
+                "sendReport",
+                toInstant(initialTime),
+                expectedTimes.stream().map(this::toInstant).toList()
+        );
+    }
+
+    private Instant toInstant(LocalDateTime time) {
+        return time.atZone(ZoneId.of("Asia/Seoul")).toInstant();
+    }
+}

--- a/src/test/java/maeilmail/subscribe/core/SendQuestionSchedulerTest.java
+++ b/src/test/java/maeilmail/subscribe/core/SendQuestionSchedulerTest.java
@@ -11,16 +11,16 @@ import org.junit.jupiter.api.Test;
 class SendQuestionSchedulerTest {
 
     @Test
-    @DisplayName("매일 아침 7시에 스케줄러가 동작하는지 확인한다.")
-    void cronTest() {
-        LocalDateTime initialTime = LocalDateTime.of(2024, 8, 26, 7, 0);
+    @DisplayName("매주 월요일부터 금요일까지 평일에 한해서 아침 7시에 질문지 전송 스케줄러가 동작하는지 확인한다.")
+    void sendMailCronWeekday() {
+        LocalDateTime initialTime = LocalDateTime.of(2024, 8, 26, 7, 0); // 월요일
         List<LocalDateTime> expectedTimes = List.of(
-                LocalDateTime.of(2024, 8, 27, 7, 0),
-                LocalDateTime.of(2024, 8, 28, 7, 0),
-                LocalDateTime.of(2024, 8, 29, 7, 0),
-                LocalDateTime.of(2024, 8, 30, 7, 0),
-                LocalDateTime.of(2024, 8, 31, 7, 0),
-                LocalDateTime.of(2024, 9, 1, 7, 0)
+                LocalDateTime.of(2024, 8, 27, 7, 0),  // 화요일
+                LocalDateTime.of(2024, 8, 28, 7, 0),  // 수요일
+                LocalDateTime.of(2024, 8, 29, 7, 0),  // 목요일
+                LocalDateTime.of(2024, 8, 30, 7, 0),  // 금요일
+                LocalDateTime.of(2024, 9, 2, 7, 0),   // 다음 주 월요일
+                LocalDateTime.of(2024, 9, 3, 7, 0)    // 다음 주 화요일
         );
         SchedulerTestUtils.assertCronExpression(
                 SendQuestionScheduler.class,

--- a/src/test/java/maeilmail/subscribe/core/SubscribeSequenceSchedulerTest.java
+++ b/src/test/java/maeilmail/subscribe/core/SubscribeSequenceSchedulerTest.java
@@ -1,0 +1,69 @@
+package maeilmail.subscribe.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import maeilmail.question.QuestionCategory;
+import maeilmail.support.SchedulerTestUtils;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SubscribeSequenceSchedulerTest {
+
+    @Autowired
+    private SubscribeSequenceScheduler subscribeSequenceScheduler;
+
+    @Autowired
+    private SubscribeRepository subscribeRepository;
+
+    @Test
+    @DisplayName("매주 월요일부터 금요일까지 평일에 한해서 저녁 10시에 시퀀스 증가 스케줄러가 동작하는지 확인한다.")
+    void increaseNextQuestionSequenceCronWeekday() {
+        LocalDateTime initialTime = LocalDateTime.of(2024, 11, 4, 22, 0); // 월요일
+        List<LocalDateTime> expectedTimes = List.of(
+                LocalDateTime.of(2024, 11, 5, 22, 0),   // 화요일
+                LocalDateTime.of(2024, 11, 6, 22, 0),   // 수요일
+                LocalDateTime.of(2024, 11, 7, 22, 0),   // 목요일
+                LocalDateTime.of(2024, 11, 8, 22, 0),   // 금요일
+                LocalDateTime.of(2024, 11, 11, 22, 0),  // 다음주 월요일
+                LocalDateTime.of(2024, 11, 12, 22, 0)   // 다음주 화요일
+        );
+        SchedulerTestUtils.assertCronExpression(
+                SubscribeSequenceScheduler.class,
+                "increaseNextQuestionSequence",
+                toInstant(initialTime),
+                expectedTimes.stream().map(this::toInstant).toList()
+        );
+    }
+
+    @Disabled
+    @DisplayName("오전 7시 이전에 구독한 구독자의 질문지 시퀀스를 증가시킨다.")
+    @Test
+    void increaseNextQuestionSequence() {
+        LocalDateTime baseDateTime = LocalDateTime.of(2024, 11, 6, 7, 0);
+        Subscribe backend = new Subscribe("test@test.com", QuestionCategory.BACKEND);
+        Subscribe frontend = new Subscribe("test@test.com", QuestionCategory.FRONTEND);
+        Subscribe afterBaseDateTimeSubscriber = new Subscribe("after@test.com", QuestionCategory.FRONTEND);
+
+        subscribeRepository.saveAll(List.of(backend, frontend, afterBaseDateTimeSubscriber));
+
+        subscribeSequenceScheduler.increaseNextQuestionSequence();
+
+        List<Subscribe> subscribes = subscribeRepository.findAll();
+
+        assertThat(subscribes.get(0).getNextQuestionSequence()).isEqualTo(1);
+        assertThat(subscribes.get(1).getNextQuestionSequence()).isEqualTo(1);
+        assertThat(subscribes.get(2).getNextQuestionSequence()).isEqualTo(0);
+    }
+
+    private Instant toInstant(LocalDateTime time) {
+        return time.atZone(ZoneId.of("Asia/Seoul")).toInstant();
+    }
+}


### PR DESCRIPTION
```java
@Scheduled(cron = "0 0 7 * * MON-FRI")
public void sendMail() {
    log.info("메일 전송을 시작합니다.");
    LocalDateTime now = ZonedDateTime.now(KOREA_ZONE).toLocalDateTime();
    List<Subscribe> subscribes = subscribeRepository.findAllByCreatedAtBefore(now);
    log.info("{}명의 사용자에게 메일을 전송합니다.", subscribes.size());

    subscribes.stream()
            .filter(it -> distributedSupport.isMine(it.getId()))
            .map(this::choiceQuestion)
            .filter(Objects::nonNull)
            .forEach(mailSender::sendMail);
}
```
sendMail에서 발송한 메일 중 성공한 메일 이벤트만 nextQuestionSequence를 증가시키려고 했습니다.
그런데 현재 MailEvent 엔티티가 Subscribe 엔티티의 id를 가지고 있지 않아서, email, type, isSuccess로 성공한 메일 이벤트에 한해서 조회한 Subscribe 객체를 가지고 구독자의 시퀀스를 증가 시켜야 하기 때문에 매우 복잡한 상황입니다.

그래서 현재 시점에서는 발송에 실패한 메일이 있다면 재전송 처리하고 22시에 스케줄을 실행하여 nextQuestionSequence를 증가하도록 작성했습니다.

```java
// SendQuestionScheduler.class
@Transactional
@Scheduled(cron = "0 0 22 * * MON-FRI")
public void increaseNextQuestionSequence() {
    LocalDateTime baseDateTime = ZonedDateTime.of(LocalDate.now(), LocalTime.of(7, 0), KOREA_ZONE).toLocalDateTime();
    subscribeRepository.increaseNextQuestionSequence(baseDateTime);
}

// SubscribeRepository.class
@Modifying
@Query("update Subscribe s set s.nextQuestionSequence = s.nextQuestionSequence + 1 where s.createdAt < :baseDateTime")
void increaseNextQuestionSequence(LocalDateTime baseDateTime);
```
SubscribeRepository에 구독자의 시퀀스를 증가시키는 bulk update 쿼리 메서드를 작성했습니다. 그리고 이 메서드를 호출하는 SendQuestionScheduler의 메서드에 `@Transactional`을 선언하여 벌크 업데이트 쿼리를 원자적으로 실행하도록 했습니다.
- close: #81 
- close: #90 