### PR TITLE
시퀀스 증가 스케줄을 1대의 서버에서만 실행하도록 변경한다.

### DIFF
--- a/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
+++ b/src/main/java/maeilmail/subscribe/core/SubscribeRepository.java
@@ -19,11 +19,11 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
     List<Subscribe> findAllByCreatedAtBefore(LocalDateTime baseDateTime);
 
-    @Modifying
     @Query("""
             update Subscribe s
             set s.nextQuestionSequence = s.nextQuestionSequence + 1
             where s.createdAt < :baseDateTime
             """)
+    @Modifying
     void increaseNextQuestionSequence(LocalDateTime baseDateTime);
 }

--- a/src/main/java/maeilmail/subscribe/core/SubscribeSequenceScheduler.java
+++ b/src/main/java/maeilmail/subscribe/core/SubscribeSequenceScheduler.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maeilmail.DistributedSupport;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,11 +20,14 @@ public class SubscribeSequenceScheduler {
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     private final SubscribeRepository subscribeRepository;
+    private final DistributedSupport distributedSupport;
 
     @Transactional
     @Scheduled(cron = "0 0 22 * * MON-FRI", zone = "Asia/Seoul")
     public void increaseNextQuestionSequence() {
-        LocalDateTime baseDateTime = ZonedDateTime.of(LocalDate.now(), LocalTime.of(7, 0), KOREA_ZONE).toLocalDateTime();
-        subscribeRepository.increaseNextQuestionSequence(baseDateTime);
+        if (distributedSupport.isMine(1L)) {
+            LocalDateTime baseDateTime = ZonedDateTime.of(LocalDate.now(), LocalTime.of(7, 0), KOREA_ZONE).toLocalDateTime();
+            subscribeRepository.increaseNextQuestionSequence(baseDateTime);
+        }
     }
 }

--- a/src/test/java/maeilmail/subscribe/core/SubscribeRepositoryTest.java
+++ b/src/test/java/maeilmail/subscribe/core/SubscribeRepositoryTest.java
@@ -1,0 +1,57 @@
+package maeilmail.subscribe.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import maeilmail.question.QuestionCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class SubscribeRepositoryTest {
+
+    @Autowired
+    private SubscribeRepository subscribeRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("구독자의 질문지 시퀀스를 증가시킨다.")
+    void increaseNextQuestionSequence() {
+        LocalDateTime baseDateTime = LocalDateTime.of(2024, 11, 7, 7, 0);
+        LocalDateTime expectedChangeTime = baseDateTime.minusSeconds(1);
+        createSubscribe("test1@test.com", QuestionCategory.BACKEND, expectedChangeTime);
+        createSubscribe("test2@test.com", QuestionCategory.FRONTEND, expectedChangeTime);
+        createSubscribe("test3@test.com", QuestionCategory.BACKEND, baseDateTime);
+
+        subscribeRepository.increaseNextQuestionSequence(baseDateTime);
+
+        List<Subscribe> subscribes = subscribeRepository.findAll();
+        assertThat(subscribes)
+                .filteredOn("nextQuestionSequence", 1L)
+                .map(Subscribe::getEmail)
+                .containsExactlyInAnyOrder("test1@test.com", "test2@test.com");
+    }
+
+    private void createSubscribe(
+            String email,
+            QuestionCategory category,
+            LocalDateTime createdAt
+    ) {
+        String sql = "insert into subscribe(email, category, next_question_sequence, created_at) values(?, ?, ?, ?);";
+        Query nativeQuery = entityManager.createNativeQuery(sql);
+        nativeQuery.setParameter(1, email);
+        nativeQuery.setParameter(2, category.toLowerCase());
+        nativeQuery.setParameter(3, 0);
+        nativeQuery.setParameter(4, createdAt);
+        nativeQuery.executeUpdate();
+    }
+}

--- a/src/test/java/maeilmail/subscribe/core/SubscribeSequenceSchedulerTest.java
+++ b/src/test/java/maeilmail/subscribe/core/SubscribeSequenceSchedulerTest.java
@@ -1,27 +1,14 @@
 package maeilmail.subscribe.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import maeilmail.question.QuestionCategory;
 import maeilmail.support.SchedulerTestUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class SubscribeSequenceSchedulerTest {
-
-    @Autowired
-    private SubscribeSequenceScheduler subscribeSequenceScheduler;
-
-    @Autowired
-    private SubscribeRepository subscribeRepository;
 
     @Test
     @DisplayName("매주 월요일부터 금요일까지 평일에 한해서 저녁 10시에 시퀀스 증가 스케줄러가 동작하는지 확인한다.")
@@ -41,26 +28,6 @@ class SubscribeSequenceSchedulerTest {
                 toInstant(initialTime),
                 expectedTimes.stream().map(this::toInstant).toList()
         );
-    }
-
-    @Disabled
-    @DisplayName("오전 7시 이전에 구독한 구독자의 질문지 시퀀스를 증가시킨다.")
-    @Test
-    void increaseNextQuestionSequence() {
-        LocalDateTime baseDateTime = LocalDateTime.of(2024, 11, 6, 7, 0);
-        Subscribe backend = new Subscribe("test@test.com", QuestionCategory.BACKEND);
-        Subscribe frontend = new Subscribe("test@test.com", QuestionCategory.FRONTEND);
-        Subscribe afterBaseDateTimeSubscriber = new Subscribe("after@test.com", QuestionCategory.FRONTEND);
-
-        subscribeRepository.saveAll(List.of(backend, frontend, afterBaseDateTimeSubscriber));
-
-        subscribeSequenceScheduler.increaseNextQuestionSequence();
-
-        List<Subscribe> subscribes = subscribeRepository.findAll();
-
-        assertThat(subscribes.get(0).getNextQuestionSequence()).isEqualTo(1);
-        assertThat(subscribes.get(1).getNextQuestionSequence()).isEqualTo(1);
-        assertThat(subscribes.get(2).getNextQuestionSequence()).isEqualTo(0);
     }
 
     private Instant toInstant(LocalDateTime time) {


### PR DESCRIPTION
- close #94 
- 시퀀스 증가 쿼리 테스트 코드 추가로 작성했는데, nativeQuery를 사용했습니다!