### PR TITLE
어드민 이관에 따른 질문 생성 수정 API를 변경한다.

### DIFF
--- a/src/main/java/maeilmail/admin/AdminController.java
+++ b/src/main/java/maeilmail/admin/AdminController.java
@@ -4,11 +4,14 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Controller
 @RequiredArgsConstructor
@@ -35,5 +38,16 @@ class AdminController {
         }
 
         return "redirect:/admin";
+    }
+
+    @PutMapping("/admin/question")
+    public ResponseEntity<Void> putQuestion(@RequestBody AdminQuestionRequest request) {
+        if (request.isUpdate()) {
+            adminQuestionService.updateQuestion(request.toQuestion());
+        } else {
+            adminQuestionService.createQuestion(request.toQuestion());
+        }
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/maeilmail/admin/AdminQuestionRequest.java
+++ b/src/main/java/maeilmail/admin/AdminQuestionRequest.java
@@ -1,0 +1,26 @@
+package maeilmail.admin;
+
+import maeilmail.question.Question;
+import maeilmail.question.QuestionCategory;
+
+record AdminQuestionRequest(
+        Long id,
+        String title,
+        String content,
+        String customizedTitle,
+        String category
+) {
+
+    public Question toQuestion() {
+        String actualCustomizedTitle = customizedTitle;
+        if (customizedTitle == null || customizedTitle.isBlank()) {
+            actualCustomizedTitle = null;
+        }
+
+        return new Question(id, title, content, actualCustomizedTitle, QuestionCategory.from(category));
+    }
+
+    public boolean isUpdate() {
+        return id != null;
+    }
+}


### PR DESCRIPTION
- close #97 
- 기존 post api는 레거시 어드민에서 사용중이기 때문에 삭제하지 않았습니다.