### PR TITLE
질문지 목록 조회 API를 구현한다.

### DIFF
--- a/src/main/java/maeilmail/PaginationResponse.java
+++ b/src/main/java/maeilmail/PaginationResponse.java
@@ -2,5 +2,5 @@ package maeilmail;
 
 import java.util.List;
 
-public record PaginationResponse<T>(boolean isLastPage, List<T> data) {
+public record PaginationResponse<T>(Boolean isLastPage, Long totalPage, List<T> data) {
 }

--- a/src/main/java/maeilmail/PaginationResponse.java
+++ b/src/main/java/maeilmail/PaginationResponse.java
@@ -1,0 +1,6 @@
+package maeilmail;
+
+import java.util.List;
+
+public record PaginationResponse<T>(boolean isLastPage, List<T> data) {
+}

--- a/src/main/java/maeilmail/question/QuestionApi.java
+++ b/src/main/java/maeilmail/question/QuestionApi.java
@@ -20,7 +20,7 @@ class QuestionApi {
     @GetMapping("/question")
     public ResponseEntity<PaginationResponse<QuestionSummary>> getQuestions(
             @RequestParam(defaultValue = "all") String category,
-            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         PaginationResponse<QuestionSummary> response = questionQueryService.pageByCategory(category, pageable);
 

--- a/src/main/java/maeilmail/question/QuestionApi.java
+++ b/src/main/java/maeilmail/question/QuestionApi.java
@@ -1,9 +1,14 @@
 package maeilmail.question;
 
 import lombok.RequiredArgsConstructor;
+import maeilmail.PaginationResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -11,6 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
 class QuestionApi {
 
     private final QuestionQueryService questionQueryService;
+
+    @GetMapping("/question")
+    public ResponseEntity<PaginationResponse<QuestionSummary>> getQuestions(
+            @RequestParam(defaultValue = "all") String category,
+            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        PaginationResponse<QuestionSummary> response = questionQueryService.pageByCategory(category, pageable);
+
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/question/{id}")
     public ResponseEntity<QuestionSummary> getQuestionById(@PathVariable Long id) {

--- a/src/main/java/maeilmail/question/QuestionQueryService.java
+++ b/src/main/java/maeilmail/question/QuestionQueryService.java
@@ -40,7 +40,7 @@ public class QuestionQueryService {
         appendOrderCondition(pageable, resultQuery);
 
         Page<QuestionSummary> pageResult = PageableExecutionUtils.getPage(resultQuery.fetch(), pageable, countQuery::fetchOne);
-        return new PaginationResponse<>(pageResult.isLast(), pageResult.getContent());
+        return new PaginationResponse<>(pageResult.isLast(), (long) pageResult.getTotalPages(), pageResult.getContent());
     }
 
     private void appendOrderCondition(Pageable pageable, JPAQuery<QuestionSummary> resultQuery) {

--- a/src/main/java/maeilmail/question/QuestionQueryService.java
+++ b/src/main/java/maeilmail/question/QuestionQueryService.java
@@ -7,6 +7,8 @@ import java.util.NoSuchElementException;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import maeilmail.PaginationResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionQueryService {
 
     private final JPAQueryFactory queryFactory;
+
+    public PaginationResponse<QuestionSummary> pageByCategory(String category, Pageable pageable) {
+        return null;
+    }
 
     public List<QuestionSummary> queryAllByCategory(String category) {
         return queryFactory.select(projectionQuestionSummary())

--- a/src/test/java/maeilmail/question/QuestionApiTest.java
+++ b/src/test/java/maeilmail/question/QuestionApiTest.java
@@ -35,7 +35,7 @@ class QuestionApiTest {
     void getQuestionsDefault() throws Exception {
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         ArgumentCaptor<String> categoryCaptor = ArgumentCaptor.forClass(String.class);
-        PaginationResponse<QuestionSummary> response = new PaginationResponse<>(false, Collections.emptyList());
+        PaginationResponse<QuestionSummary> response = new PaginationResponse<>(true, 0L, Collections.emptyList());
         when(questionQueryService.pageByCategory(any(), any()))
                 .thenReturn(response);
 

--- a/src/test/java/maeilmail/question/QuestionApiTest.java
+++ b/src/test/java/maeilmail/question/QuestionApiTest.java
@@ -1,0 +1,58 @@
+package maeilmail.question;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import maeilmail.PaginationResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(QuestionApi.class)
+class QuestionApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private QuestionQueryService questionQueryService;
+
+    @Test
+    @DisplayName("페이징 처리된 질문지를 조회할때 기본 값은 page = 0, pageSize = 10, category = 'all' 이다.")
+    void getQuestionsDefault() throws Exception {
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        ArgumentCaptor<String> categoryCaptor = ArgumentCaptor.forClass(String.class);
+        PaginationResponse<QuestionSummary> response = new PaginationResponse<>(false, Collections.emptyList());
+        when(questionQueryService.pageByCategory(any(), any()))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/question"))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+
+        verify(questionQueryService, times(1))
+                .pageByCategory(categoryCaptor.capture(), pageableCaptor.capture());
+        Pageable actualPageable = pageableCaptor.getValue();
+        String actualCategory = categoryCaptor.getValue();
+
+        assertAll(
+                () -> assertThat(actualCategory).isEqualTo("all"),
+                () -> assertThat(actualPageable.getPageSize()).isEqualTo(10),
+                () -> assertThat(actualPageable.getPageNumber()).isEqualTo(0)
+        );
+    }
+}

--- a/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
+++ b/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
@@ -88,6 +88,7 @@ class QuestionQueryServiceTest extends IntegrationTestSupport {
         assertAll(
                 () -> assertThat(response.isLastPage()).isFalse(),
                 () -> assertThat(response.data()).hasSize(3),
+                () -> assertThat(response.totalPage()).isEqualTo(4),
                 () -> assertThat(response.data())
                         .map(QuestionSummary::id)
                         .containsExactlyElementsOf(expectedIds)

--- a/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
+++ b/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
@@ -2,13 +2,17 @@ package maeilmail.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import maeilmail.PaginationResponse;
 import maeilmail.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 class QuestionQueryServiceTest extends IntegrationTestSupport {
 
@@ -64,6 +68,30 @@ class QuestionQueryServiceTest extends IntegrationTestSupport {
         assertThat(all.size()).isEqualTo(3);
         assertThat(ALL.size()).isEqualTo(3);
         assertThat(nul.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("페이징처리하여 질문지를 조회한다.")
+    void pageByCategory() {
+        List<Long> backendIds = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Question question = createQuestion(QuestionCategory.BACKEND);
+            backendIds.add(question.getId());
+            createQuestion(QuestionCategory.FRONTEND);
+        }
+
+        int pageSize = 3;
+        List<Long> expectedIds = backendIds.subList(0, pageSize);
+        PaginationResponse<QuestionSummary> response
+                = questionQueryService.pageByCategory("backend", PageRequest.of(0, pageSize));
+
+        assertAll(
+                () -> assertThat(response.isLastPage()).isFalse(),
+                () -> assertThat(response.data()).hasSize(3),
+                () -> assertThat(response.data())
+                        .map(QuestionSummary::id)
+                        .containsExactlyElementsOf(expectedIds)
+        );
     }
 
     private Question createQuestion(QuestionCategory category) {

--- a/src/test/java/maeilmail/support/IntegrationTestSupport.java
+++ b/src/test/java/maeilmail/support/IntegrationTestSupport.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import maeilmail.mail.MailSender;
 import org.hibernate.cfg.AvailableSettings;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-@AutoConfigureMockMvc
 @Import(IntegrationTestSupport.TestConfig.class)
 public abstract class IntegrationTestSupport {
 

--- a/src/test/java/maeilmail/support/IntegrationTestSupport.java
+++ b/src/test/java/maeilmail/support/IntegrationTestSupport.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import maeilmail.mail.MailSender;
 import org.hibernate.cfg.AvailableSettings;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureMockMvc
 @Import(IntegrationTestSupport.TestConfig.class)
 public abstract class IntegrationTestSupport {
 


### PR DESCRIPTION
- close #98 
- 어드민에서 사용될 질문지 목록 조회 api를 구현했습니다. 
- 외부에 노출되어도 문제없는 api라 판단하여 `/admin` 경로를 사용하지 않았습니다.