### PR TITLE
구독자별로 지금까지 받은 질문지를 모아보는 기능을 구현한다.

### DIFF
--- a/src/main/java/maeilmail/admin/AdminReportScheduler.java
+++ b/src/main/java/maeilmail/admin/AdminReportScheduler.java
@@ -28,7 +28,7 @@ class AdminReportScheduler {
     @Scheduled(cron = "0 30 7 * * MON-FRI", zone = "Asia/Seoul")
     public void sendReport() {
         log.info("관리자 결과 전송, date = {}", LocalDate.now());
-        EventReport report = statisticsService.generateDailyMailEventReport("question");
+        EventReport report = statisticsService.generateDailySubscribeQuestionReport();
         String text = createText(report);
         String subject = "[관리자] 메일 전송 결과를 알려드립니다.";
 

--- a/src/main/java/maeilmail/question/QuestionSummary.java
+++ b/src/main/java/maeilmail/question/QuestionSummary.java
@@ -7,4 +7,8 @@ public record QuestionSummary(Long id, String title, String content, String cust
     @QueryProjection
     public QuestionSummary {
     }
+
+    public Question toQuestion() {
+        return new Question(this.id, this.title, this.content, this.customizedTitle, QuestionCategory.from(this.category));
+    }
 }

--- a/src/main/java/maeilmail/statistics/EventAggregator.java
+++ b/src/main/java/maeilmail/statistics/EventAggregator.java
@@ -3,17 +3,16 @@ package maeilmail.statistics;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import maeilmail.mail.MailEvent;
+import maeilmail.subscribequestion.SubscribeQuestion;
 import org.springframework.stereotype.Component;
 
 @Component
 class EventAggregator {
 
-    public EventReport aggregate(String type, List<MailEvent> events) {
-        Map<Boolean, Long> result = events.stream()
-                .filter(it -> it.getType().startsWith(type))
-                .collect(Collectors.partitioningBy(MailEvent::isSuccess, Collectors.counting()));
+    public EventReport aggregate(List<SubscribeQuestion> subscribeQuestions) {
+        Map<Boolean, Long> result = subscribeQuestions.stream()
+                .collect(Collectors.partitioningBy(SubscribeQuestion::isSuccess, Collectors.counting()));
 
-        return new EventReport(type, result.get(true), result.get(false));
+        return new EventReport("subscribeQuestion", result.get(true), result.get(false));
     }
 }

--- a/src/main/java/maeilmail/statistics/StatisticsApi.java
+++ b/src/main/java/maeilmail/statistics/StatisticsApi.java
@@ -18,9 +18,9 @@ class StatisticsApi {
         return ResponseEntity.ok(report);
     }
 
-    @GetMapping("/statistics/mail-event/question")
-    public ResponseEntity<EventReport> getDailyMailEventReport() {
-        EventReport report = statisticsService.generateDailyMailEventReport("question");
+    @GetMapping("/statistics/subscribe-question")
+    public ResponseEntity<EventReport> getDailySubscribeQuestionReport() {
+        EventReport report = statisticsService.generateDailySubscribeQuestionReport();
 
         return ResponseEntity.ok(report);
     }

--- a/src/main/java/maeilmail/statistics/StatisticsService.java
+++ b/src/main/java/maeilmail/statistics/StatisticsService.java
@@ -19,7 +19,7 @@ public class StatisticsService {
     private final SubscribeQuestionRepository subscribeQuestionRepository;
     private final EventAggregator eventAggregator;
 
-    public EventReport generateDailyMailEventReport() {
+    public EventReport generateDailySubscribeQuestionReport() {
         LocalDate today = LocalDate.now();
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.plusDays(1).atStartOfDay().minusNanos(1);

--- a/src/main/java/maeilmail/statistics/StatisticsService.java
+++ b/src/main/java/maeilmail/statistics/StatisticsService.java
@@ -4,9 +4,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import maeilmail.mail.MailEvent;
-import maeilmail.mail.MailEventRepository;
 import maeilmail.subscribe.core.SubscribeRepository;
+import maeilmail.subscribequestion.SubscribeQuestion;
+import maeilmail.subscribequestion.SubscribeQuestionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,16 +16,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class StatisticsService {
 
     private final SubscribeRepository subscribeRepository;
-    private final MailEventRepository mailEventRepository;
+    private final SubscribeQuestionRepository subscribeQuestionRepository;
     private final EventAggregator eventAggregator;
 
-    public EventReport generateDailyMailEventReport(String type) {
+    public EventReport generateDailyMailEventReport() {
         LocalDate today = LocalDate.now();
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.plusDays(1).atStartOfDay().minusNanos(1);
-        List<MailEvent> result = mailEventRepository.findMailEventByCreatedAtBetween(startOfDay, endOfDay);
+        List<SubscribeQuestion> result = subscribeQuestionRepository.findSubscribeQuestionByCreatedAtBetween(startOfDay, endOfDay);
 
-        return eventAggregator.aggregate(type, result);
+        return eventAggregator.aggregate(result);
     }
 
     public SubscribeReport generateSubscribeReport() {

--- a/src/main/java/maeilmail/subscribequestion/ChoiceQuestionPolicy.java
+++ b/src/main/java/maeilmail/subscribequestion/ChoiceQuestionPolicy.java
@@ -1,7 +1,8 @@
-package maeilmail.subscribe.core;
+package maeilmail.subscribequestion;
 
 import java.time.LocalDate;
 import maeilmail.question.QuestionSummary;
+import maeilmail.subscribe.core.Subscribe;
 
 public interface ChoiceQuestionPolicy {
 

--- a/src/main/java/maeilmail/subscribequestion/QuestionSender.java
+++ b/src/main/java/maeilmail/subscribequestion/QuestionSender.java
@@ -1,0 +1,71 @@
+package maeilmail.subscribequestion;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maeilmail.question.Question;
+import maeilmail.question.QuestionCategory;
+import maeilmail.subscribe.core.Subscribe;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component(value = "questionSender")
+@RequiredArgsConstructor
+public class QuestionSender {
+
+    private static final int MAIL_SENDER_RATE_MILLISECONDS = 500;
+    private static final String FROM_EMAIL = "maeil-mail <maeil-mail-noreply@maeil-mail.site>";
+
+    private final JavaMailSender javaMailSender;
+    private final SubscribeQuestionRepository subscribeQuestionRepository;
+
+    @Async
+    public void sendMail(SubscribeQuestionMessage message) {
+        Subscribe subscribe = message.subscribe();
+        Question question = message.question();
+        QuestionCategory questionCategory = question.getCategory();
+
+        String to = subscribe.getEmail();
+        String subject = message.subject();
+        String text = message.text();
+        String category = questionCategory.toLowerCase();
+        try {
+            log.info("질문지를 전송합니다. email = {}, questionId = {}, subject = {}, category = {}", to, question.getId(), subject, category);
+            MimeMessage mimeMessage = convertToMime(to, subject, text);
+            javaMailSender.send(mimeMessage);
+            subscribeQuestionRepository.save(SubscribeQuestion.success(subscribe, question));
+        } catch (MessagingException | MailException e) {
+            log.error("메일 전송 실패: email = {}, questionId = {}, subject = {}, category = {}, 오류 = {}", to, question.getId(), subject, category.toLowerCase(), e.getMessage(), e);
+            subscribeQuestionRepository.save(SubscribeQuestion.fail(subscribe, question));
+        } catch (Exception e) {
+            log.error("예기치 않은 오류 발생: email = {}, questionId = {}, subject = {}, category = {}, 오류 = {}", to, question.getId(), subject, category.toLowerCase(), e.getMessage(), e);
+            subscribeQuestionRepository.save(SubscribeQuestion.fail(subscribe, question));
+        } finally {
+            try {
+                Thread.sleep(MAIL_SENDER_RATE_MILLISECONDS);
+            } catch (InterruptedException ignored) {
+            }
+        }
+    }
+
+    private MimeMessage convertToMime(String to, String subject, String text) throws MessagingException {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        tryAppendOpenEventTrace(mimeMessage);
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        mimeMessageHelper.setFrom(FROM_EMAIL);
+        mimeMessageHelper.setTo(to);
+        mimeMessageHelper.setSubject(subject);
+        mimeMessageHelper.setText(text, true);
+        return mimeMessage;
+    }
+
+    private void tryAppendOpenEventTrace(MimeMessage mimeMessage) throws MessagingException {
+        mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
+        mimeMessage.setHeader("X-SES-MESSAGE_TAGS", "mail-open");
+    }
+}

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestion.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestion.java
@@ -1,0 +1,47 @@
+package maeilmail.subscribequestion;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import maeilmail.question.Question;
+import maeilmail.subscribe.core.Subscribe;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "subscribe_question")
+@Entity
+public class SubscribeQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Subscribe subscribe;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Question question;
+
+    private boolean isSuccess;
+
+    protected SubscribeQuestion(Subscribe subscribe, Question question, boolean isSuccess) {
+        this.subscribe = subscribe;
+        this.question = question;
+        this.isSuccess = isSuccess;
+    }
+
+    public static SubscribeQuestion success(Subscribe subscribe, Question question) {
+        return new SubscribeQuestion(subscribe, question, true);
+    }
+
+    public static SubscribeQuestion fail(Subscribe subscribe, Question question) {
+        return new SubscribeQuestion(subscribe, question, false);
+    }
+}

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestion.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestion.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import maeilmail.BaseEntity;
 import maeilmail.question.Question;
 import maeilmail.subscribe.core.Subscribe;
 
@@ -17,7 +18,7 @@ import maeilmail.subscribe.core.Subscribe;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "subscribe_question")
 @Entity
-public class SubscribeQuestion {
+public class SubscribeQuestion extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +32,7 @@ public class SubscribeQuestion {
 
     private boolean isSuccess;
 
-    protected SubscribeQuestion(Subscribe subscribe, Question question, boolean isSuccess) {
+    public SubscribeQuestion(Subscribe subscribe, Question question, boolean isSuccess) {
         this.subscribe = subscribe;
         this.question = question;
         this.isSuccess = isSuccess;

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionApi.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionApi.java
@@ -1,0 +1,29 @@
+package maeilmail.subscribequestion;
+
+import lombok.RequiredArgsConstructor;
+import maeilmail.PaginationResponse;
+import maeilmail.question.QuestionSummary;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SubscribeQuestionApi {
+
+    private final SubscribeQuestionQueryService subscribeQuestionQueryService;
+
+    @GetMapping("/subscribe-question")
+    public ResponseEntity<PaginationResponse<QuestionSummary>> getSubscribeQuestion(
+            @RequestParam String email,
+            @RequestParam(defaultValue = "all") String category,
+            @PageableDefault(sort = {"category", "id"}) Pageable pageable
+    ) {
+        PaginationResponse<QuestionSummary> response = subscribeQuestionQueryService.pageByEmailAndCategory(email, category, pageable);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionMessage.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionMessage.java
@@ -1,0 +1,12 @@
+package maeilmail.subscribequestion;
+
+import maeilmail.question.Question;
+import maeilmail.subscribe.core.Subscribe;
+
+public record SubscribeQuestionMessage(
+        Subscribe subscribe,
+        Question question,
+        String subject,
+        String text
+) {
+}

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
@@ -1,0 +1,87 @@
+package maeilmail.subscribequestion;
+
+import static maeilmail.question.QQuestion.question;
+import static maeilmail.subscribe.core.QSubscribe.subscribe;
+import static maeilmail.subscribequestion.QSubscribeQuestion.subscribeQuestion;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import maeilmail.PaginationResponse;
+import maeilmail.question.QQuestionSummary;
+import maeilmail.question.Question;
+import maeilmail.question.QuestionCategory;
+import maeilmail.question.QuestionSummary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscribeQuestionQueryService {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PaginationResponse<QuestionSummary> pageByEmailAndCategory(String email, String category, Pageable pageable) {
+        JPAQuery<Long> countQuery = queryFactory.select(subscribeQuestion.count())
+                .from(subscribeQuestion)
+                .join(subscribe).on(subscribeQuestion.subscribe.eq(subscribe))
+                .where(eqEmail(email)
+                        .and(eqCategory(category))
+                        .and(subscribeQuestion.isSuccess));
+        JPAQuery<QuestionSummary> resultQuery = queryFactory.select(projectionQuestionSummary())
+                .from(subscribeQuestion)
+                .join(subscribe).on(subscribeQuestion.subscribe.eq(subscribe))
+                .join(question).on(subscribeQuestion.question.eq(question))
+                .where(eqEmail(email)
+                        .and(eqCategory(category))
+                        .and(subscribeQuestion.isSuccess))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        appendOrderCondition(pageable, resultQuery);
+
+        Page<QuestionSummary> pageResult = PageableExecutionUtils.getPage(resultQuery.fetch(), pageable, countQuery::fetchOne);
+        return new PaginationResponse<>(pageResult.isLast(), (long) pageResult.getTotalPages(), pageResult.getContent());
+    }
+
+    private BooleanExpression eqEmail(String email) {
+        return subscribe.email.eq(email);
+    }
+
+    private BooleanExpression eqCategory(String category) {
+        if (category == null || "all".equalsIgnoreCase(category)) {
+            return null;
+        }
+
+        return question.category.eq(QuestionCategory.from(category));
+    }
+
+    private void appendOrderCondition(Pageable pageable, JPAQuery<QuestionSummary> resultQuery) {
+        for (Sort.Order order : pageable.getSort()) {
+            PathBuilder<Question> entityPath = new PathBuilder<>(question.getType(), question.getMetadata());
+            Expression orderExpression = entityPath.get(order.getProperty());
+            OrderSpecifier orderSpecifier = new OrderSpecifier<>(order.isAscending() ? Order.ASC : Order.DESC, orderExpression);
+            resultQuery.orderBy(orderSpecifier);
+        }
+    }
+
+    private QQuestionSummary projectionQuestionSummary() {
+        return new QQuestionSummary(
+                question.id,
+                question.title,
+                question.content,
+                question.customizedTitle,
+                question.category.stringValue().lower()
+        );
+    }
+}

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionRepository.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionRepository.java
@@ -1,0 +1,7 @@
+package maeilmail.subscribequestion;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscribeQuestionRepository extends JpaRepository<SubscribeQuestion, Long> {
+
+}

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionRepository.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionRepository.java
@@ -1,7 +1,10 @@
 package maeilmail.subscribequestion;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscribeQuestionRepository extends JpaRepository<SubscribeQuestion, Long> {
 
+    List<SubscribeQuestion> findSubscribeQuestionByCreatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionView.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionView.java
@@ -1,4 +1,4 @@
-package maeilmail.subscribe.core;
+package maeilmail.subscribequestion;
 
 import java.util.Map;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/maeilmail/subscribequestion/policy/PersonalSequenceChoicePolicy.java
+++ b/src/main/java/maeilmail/subscribequestion/policy/PersonalSequenceChoicePolicy.java
@@ -1,4 +1,4 @@
-package maeilmail.subscribe.core.policy;
+package maeilmail.subscribequestion.policy;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 import maeilmail.question.QuestionCategory;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
-import maeilmail.subscribe.core.ChoiceQuestionPolicy;
 import maeilmail.subscribe.core.Subscribe;
+import maeilmail.subscribequestion.ChoiceQuestionPolicy;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/maeilmail/subscribequestion/policy/RandomChoicePolicy.java
+++ b/src/main/java/maeilmail/subscribequestion/policy/RandomChoicePolicy.java
@@ -1,4 +1,4 @@
-package maeilmail.subscribe.core.policy;
+package maeilmail.subscribequestion.policy;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -6,8 +6,8 @@ import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
-import maeilmail.subscribe.core.ChoiceQuestionPolicy;
 import maeilmail.subscribe.core.Subscribe;
+import maeilmail.subscribequestion.ChoiceQuestionPolicy;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/maeilmail/subscribequestion/policy/SequenceChoicePolicy.java
+++ b/src/main/java/maeilmail/subscribequestion/policy/SequenceChoicePolicy.java
@@ -1,28 +1,35 @@
-package maeilmail.subscribe.core.policy;
+package maeilmail.subscribequestion.policy;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
-import maeilmail.subscribe.core.ChoiceQuestionPolicy;
 import maeilmail.subscribe.core.Subscribe;
-import org.springframework.context.annotation.Primary;
+import maeilmail.subscribequestion.ChoiceQuestionPolicy;
 import org.springframework.stereotype.Component;
 
-@Primary
 @Component
 @RequiredArgsConstructor
-class WeekdaysPersonalSequenceChoicePolicy implements ChoiceQuestionPolicy {
+class SequenceChoicePolicy implements ChoiceQuestionPolicy {
 
+    private final LocalDate baseDate = LocalDate.of(2024, 9, 23);
     private final QuestionQueryService questionQueryService;
 
     @Override
-    public QuestionSummary choice(Subscribe subscribe, LocalDate ignore) {
+    public QuestionSummary choice(Subscribe subscribe, LocalDate today) {
+        validateInvalidDate(today);
         List<QuestionSummary> questions = findQuestions(subscribe);
-        Long nextQuestionSequence = subscribe.getNextQuestionSequence();
+        Period period = Period.between(baseDate, today);
 
-        return questions.get(nextQuestionSequence.intValue() % questions.size());
+        return questions.get(period.getDays() % questions.size());
+    }
+
+    private void validateInvalidDate(LocalDate today) {
+        if (baseDate.isAfter(today)) {
+            throw new IllegalArgumentException("질문지를 결정할 수 없습니다.");
+        }
     }
 
     private List<QuestionSummary> findQuestions(Subscribe subscribe) {

--- a/src/main/java/maeilmail/subscribequestion/policy/WeekdaysPersonalSequenceChoicePolicy.java
+++ b/src/main/java/maeilmail/subscribequestion/policy/WeekdaysPersonalSequenceChoicePolicy.java
@@ -1,35 +1,28 @@
-package maeilmail.subscribe.core.policy;
+package maeilmail.subscribequestion.policy;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
-import maeilmail.subscribe.core.ChoiceQuestionPolicy;
 import maeilmail.subscribe.core.Subscribe;
+import maeilmail.subscribequestion.ChoiceQuestionPolicy;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
+@Primary
 @Component
 @RequiredArgsConstructor
-class SequenceChoicePolicy implements ChoiceQuestionPolicy {
+class WeekdaysPersonalSequenceChoicePolicy implements ChoiceQuestionPolicy {
 
-    private final LocalDate baseDate = LocalDate.of(2024, 9, 23);
     private final QuestionQueryService questionQueryService;
 
     @Override
-    public QuestionSummary choice(Subscribe subscribe, LocalDate today) {
-        validateInvalidDate(today);
+    public QuestionSummary choice(Subscribe subscribe, LocalDate ignore) {
         List<QuestionSummary> questions = findQuestions(subscribe);
-        Period period = Period.between(baseDate, today);
+        Long nextQuestionSequence = subscribe.getNextQuestionSequence();
 
-        return questions.get(period.getDays() % questions.size());
-    }
-
-    private void validateInvalidDate(LocalDate today) {
-        if (baseDate.isAfter(today)) {
-            throw new IllegalArgumentException("질문지를 결정할 수 없습니다.");
-        }
+        return questions.get(nextQuestionSequence.intValue() % questions.size());
     }
 
     private List<QuestionSummary> findQuestions(Subscribe subscribe) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -23,8 +23,16 @@ values ('백엔드 질문 1',
 
 insert into subscribe(email, category, next_question_sequence)
 values ('leehaneul990623@gmail.com', 'BACKEND', 0),
-       ('leehaneul0623@gmail.com', 'FRONTEND', 0);
+       ('leehaneul0623@gmail.com', 'FRONTEND', 0),
+       ('gosmdochee@gmail.com', 'BACKEND', 0)
+;
 
 insert into admin(email)
 values ('leehaneul990623@gmail.com'),
        ('leehaneul0623@gmail.com');
+
+insert into subscribe_question(subscribe_id, question_id, is_success)
+values (3, 2, true),
+       (3, 7, true),
+       (3, 1, false),
+       (3, 5, true)

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -51,3 +51,12 @@ create table temporal_subscribe
     updated_at  timestamp(6),
     primary key (id)
 );
+
+create table subscribe_question
+(
+    id           bigint auto_increment,
+    question_id  bigint,
+    subscribe_id bigint,
+    is_success   boolean not null,
+    primary key (id)
+);

--- a/src/test/java/maeilmail/statistics/EventAggregatorTest.java
+++ b/src/test/java/maeilmail/statistics/EventAggregatorTest.java
@@ -3,7 +3,10 @@ package maeilmail.statistics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import maeilmail.mail.MailEvent;
+import maeilmail.question.Question;
+import maeilmail.question.QuestionCategory;
+import maeilmail.subscribe.core.Subscribe;
+import maeilmail.subscribequestion.SubscribeQuestion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,20 +16,25 @@ class EventAggregatorTest {
     @DisplayName("메일 이벤트를 받으면 하루 결과로 변환한다.")
     void report() {
         EventAggregator eventAggregator = new EventAggregator();
-        List<MailEvent> events = List.of(
-                createMailEvent(true, "type"),
-                createMailEvent(true, "none"),
-                createMailEvent(false, "type"),
-                createMailEvent(true, "type")
+
+        List<SubscribeQuestion> subscribeQuestions = List.of(
+                createSubscribeQuestion(true),
+                createSubscribeQuestion(true),
+                createSubscribeQuestion(false),
+                createSubscribeQuestion(true)
         );
 
-        EventReport result = eventAggregator.aggregate("type", events);
+        EventReport result = eventAggregator.aggregate(subscribeQuestions);
 
-        assertThat(result.success()).isEqualTo(2);
+        assertThat(result.success()).isEqualTo(3);
         assertThat(result.fail()).isEqualTo(1);
     }
 
-    private MailEvent createMailEvent(boolean isSuccess, String type) {
-        return new MailEvent(1L, "sample@test.com", type, isSuccess);
+    private SubscribeQuestion createSubscribeQuestion(boolean isSuccess) {
+        return new SubscribeQuestion(
+                new Subscribe("test@gmail.com", QuestionCategory.BACKEND),
+                new Question("test-title", "test-content", QuestionCategory.BACKEND),
+                isSuccess
+        );
     }
 }

--- a/src/test/java/maeilmail/subscribequestion/SendQuestionSchedulerTest.java
+++ b/src/test/java/maeilmail/subscribequestion/SendQuestionSchedulerTest.java
@@ -1,4 +1,4 @@
-package maeilmail.subscribe.core;
+package maeilmail.subscribequestion;
 
 import java.time.Instant;
 import java.time.LocalDateTime;

--- a/src/test/java/maeilmail/subscribequestion/SubscribeQuestionApiTest.java
+++ b/src/test/java/maeilmail/subscribequestion/SubscribeQuestionApiTest.java
@@ -1,0 +1,61 @@
+package maeilmail.subscribequestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import maeilmail.PaginationResponse;
+import maeilmail.question.QuestionSummary;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SubscribeQuestionApi.class)
+class SubscribeQuestionApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SubscribeQuestionQueryService subscribeQuestionQueryService;
+
+    @DisplayName("페이징 처리된 질문지를 조회할때 기본 값은 page = 0, pageSize = 10, category = 'all' 이다.")
+    @Test
+    void getSubscribeQuestionDefault() throws Exception {
+        String email = "test@gmail.com";
+        ArgumentCaptor<String> categoryCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        PaginationResponse<QuestionSummary> response = new PaginationResponse<>(true, 0L, Collections.emptyList());
+
+        when(subscribeQuestionQueryService.pageByEmailAndCategory(anyString(), anyString(), any()))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/subscribe-question").queryParam("email", email))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(subscribeQuestionQueryService, times(1))
+                .pageByEmailAndCategory(anyString(), categoryCaptor.capture(), pageableCaptor.capture());
+        Pageable actualPageable = pageableCaptor.getValue();
+        String actualCategory = categoryCaptor.getValue();
+
+        assertAll(
+                () -> assertThat(actualCategory).isEqualTo("all"),
+                () -> assertThat(actualPageable.getPageSize()).isEqualTo(10),
+                () -> assertThat(actualPageable.getPageNumber()).isEqualTo(0)
+        );
+    }
+}

--- a/src/test/java/maeilmail/subscribequestion/SubscribeQuestionQueryServiceTest.java
+++ b/src/test/java/maeilmail/subscribequestion/SubscribeQuestionQueryServiceTest.java
@@ -1,0 +1,111 @@
+package maeilmail.subscribequestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import maeilmail.PaginationResponse;
+import maeilmail.question.Question;
+import maeilmail.question.QuestionCategory;
+import maeilmail.question.QuestionRepository;
+import maeilmail.question.QuestionSummary;
+import maeilmail.subscribe.core.Subscribe;
+import maeilmail.subscribe.core.SubscribeRepository;
+import maeilmail.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+class SubscribeQuestionQueryServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private SubscribeQuestionQueryService subscribeQuestionQueryService;
+
+    @Autowired
+    private SubscribeQuestionRepository subscribeQuestionRepository;
+
+    @Autowired
+    private SubscribeRepository subscribeRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @BeforeEach
+    void setUp() {
+        // subscribers
+        Subscribe subscribe1 = new Subscribe("111@gmail.com", QuestionCategory.BACKEND);
+        Subscribe subscribe2 = new Subscribe("222@gmail.com", QuestionCategory.BACKEND);
+        Subscribe subscribe3 = new Subscribe("333@gmail.com", QuestionCategory.FRONTEND);
+        subscribeRepository.saveAll(List.of(subscribe1, subscribe2, subscribe3));
+
+        // questions
+        Question question1 = new Question("title-1", "cotent-1", QuestionCategory.BACKEND);
+        Question question2 = new Question("title-2", "cotent-2", QuestionCategory.BACKEND);
+        Question question3 = new Question("title-3", "cotent-3", QuestionCategory.BACKEND);
+        Question question4 = new Question("title-4", "cotent-4", QuestionCategory.FRONTEND);
+        Question question5 = new Question("title-5", "cotent-5", QuestionCategory.FRONTEND);
+        questionRepository.saveAll(List.of(question1, question2, question3, question4, question5));
+
+        // target subscriber's subscribeQuestions
+        SubscribeQuestion subscribeQuestion1 = new SubscribeQuestion(subscribe1, question1, true);
+        SubscribeQuestion subscribeQuestion2 = new SubscribeQuestion(subscribe1, question2, true);
+        SubscribeQuestion subscribeQuestion3 = new SubscribeQuestion(subscribe1, question4, true);
+
+        // other subscriber's
+        SubscribeQuestion subscribeQuestion4 = new SubscribeQuestion(subscribe2, question1, true);
+        SubscribeQuestion subscribeQuestion5 = new SubscribeQuestion(subscribe2, question4, true);
+        SubscribeQuestion subscribeQuestion6 = new SubscribeQuestion(subscribe2, question2, true);
+        SubscribeQuestion subscribeQuestion7 = new SubscribeQuestion(subscribe2, question5, true);
+        subscribeQuestionRepository.saveAll(
+                List.of(subscribeQuestion1,
+                        subscribeQuestion2,
+                        subscribeQuestion3,
+                        subscribeQuestion4,
+                        subscribeQuestion5,
+                        subscribeQuestion6,
+                        subscribeQuestion7)
+        );
+    }
+
+    @DisplayName("구독자의 이메일과 카테고리에 따라 여태까지 받은 모든 질문지를 조회한다.")
+    @Test
+    void pageByEmailAndCategory() {
+        PaginationResponse<QuestionSummary> response =
+                subscribeQuestionQueryService.pageByEmailAndCategory(
+                        "111@gmail.com",
+                        "backend",
+                        PageRequest.of(0, 10)
+                );
+
+        assertAll(
+                () -> assertThat(response.isLastPage()).isTrue(),
+                () -> assertThat(response.data()).hasSize(2),
+                () -> assertThat(response.totalPage()).isEqualTo(1),
+                () -> assertThat(response.data())
+                        .map(QuestionSummary::title)
+                        .containsExactlyElementsOf(List.of("title-1", "title-2"))
+        );
+    }
+
+    @DisplayName("카테고리가 all 이면 구독자가 받은 모든 카테고리의 질문을 조회한다.")
+    @Test
+    void pageByEmailAndDefaultCategory() {
+        PaginationResponse<QuestionSummary> response =
+                subscribeQuestionQueryService.pageByEmailAndCategory(
+                        "111@gmail.com",
+                        "all",
+                        PageRequest.of(0, 10)
+                );
+
+        assertAll(
+                () -> assertThat(response.isLastPage()).isTrue(),
+                () -> assertThat(response.data()).hasSize(3),
+                () -> assertThat(response.totalPage()).isEqualTo(1),
+                () -> assertThat(response.data())
+                        .map(QuestionSummary::title)
+                        .containsExactlyElementsOf(List.of("title-1", "title-2", "title-4"))
+        );
+    }
+}

--- a/src/test/java/maeilmail/subscribequestion/policy/PersonalSequenceChoicePolicyTest.java
+++ b/src/test/java/maeilmail/subscribequestion/policy/PersonalSequenceChoicePolicyTest.java
@@ -1,4 +1,4 @@
-package maeilmail.subscribe.core.policy;
+package maeilmail.subscribequestion.policy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/maeilmail/subscribequestion/policy/SequenceChoicePolicyTest.java
+++ b/src/test/java/maeilmail/subscribequestion/policy/SequenceChoicePolicyTest.java
@@ -1,4 +1,4 @@
-package maeilmail.subscribe.core.policy;
+package maeilmail.subscribequestion.policy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
- close: #101 

위 이슈 내용을 참고하면 기존에 질문지 메일이 발송되면 MailEvent 엔티티가 저장되는데, 해당 MailEvent를 조회해도 어떤 질문지가 발송됐는지 알 수 없는 문제가 있었습니다. 엄밀히 말하면 구독자의 구독일, 질문지가 추가된 날짜, 발송 완료된 질문지 개수 및 날짜를 역산해서 찾을 수 있겠지만, 질문지를 모아보는 기능을 구현하기에는 너무 비효율적이기 때문에 새로운 SubscribeQuestion 엔티티를 추가하여 구독자의 카테고리별 질문지를 바로 확인할 수 있도록 했습니다.

기존에는 메일을 보내는 책임을 전부 지닌 MailSender가 질문지 또한 보내고, 보내는데 성공하거나 실패한 이벤트를 MailEvent 엔티티로 저장했었는데, 이번 pr에 구독자가 받은 질문을 모으는 SubscribeQuestion 엔티티를 만들면서 분리했습니다. 그래서 질문지를 보내는 책임을 가지는 SendQuestionSender와 질문지 선택 정책들을 subscribequestion 패키지로 옮겼습니다.

SubscribeQuestion은 Subscribe와 Question의 다대다 중간 테이블로 구독자가 구독 신청한 카테고리의 질문을 하루에 한개씩 받게 되는데, 성공하거나 실패할 때 엔티티로 저장됩니다. 그래서 만약에 발송에 실패한 질문지가 있다면, subscribeQuestionRepository에서 조회 후 재발송 하면 됩니다.

SubscribeQuestionApi.getSubscribeQuestion 메서드로 구독자의 이메일과 카테고리를 쿼리 파라미터로 넘겨주면 해당 구독자가 여태까지 받은 카테고리별 질문지를 모두 조회할 수 있습니다. 구독자의 이메일은 필수이고, 카테고리를 넘겨주지 않으면 디폴트 값으로 all이 넘어갑니다. 그럼 해당 구독자의 메일로 등록된 모든 분야의 질문지가 조회됩니다. 단일 카테고리 조회시 정렬 기준은 질문지 id 오름차순이며, 모든 카테고리 조회시 정렬 기준은 카테고리, 동일 카테고리 내 질문지 id 오름차순입니다.
