### PR TITLE
스프링 graceful shutdown을 설정한다.

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,9 @@
+server:
+  shutdown: graceful
+
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   datasource:
     url: jdbc:h2:mem:testdb
     driverClassName: org.h2.Driver

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,9 @@
+server:
+  shutdown: graceful
+
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   datasource:
     url: jdbc:mysql://${db.endpoint}/${db.dbname}?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
     driverClassName: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
- close: #110 

local, prod yml에 graceful shutdown을 적용했습니다.
배포를 스케쥴러가 돌아가는 시간대에 하지 않을 것이기도 하고, 
데드 락이 걸릴 만한 지점도 없어서 일단 default time-out과 동일하게 30초로 설정했습니다.