### PR TITLE
구독 해지 기능을 구현한다.

### DIFF
--- a/src/main/java/maeilmail/mail/MailEventRepository.java
+++ b/src/main/java/maeilmail/mail/MailEventRepository.java
@@ -1,10 +1,6 @@
 package maeilmail.mail;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MailEventRepository extends JpaRepository<MailEvent, Long> {
-
-    List<MailEvent> findMailEventByCreatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/maeilmail/subscribe/Subscribe.java
+++ b/src/main/java/maeilmail/subscribe/Subscribe.java
@@ -1,5 +1,7 @@
 package maeilmail.subscribe;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -34,16 +36,29 @@ public class Subscribe extends BaseEntity {
     @Column(nullable = false)
     private Long nextQuestionSequence;
 
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = true)
+    private LocalDateTime deletedAt;
+
     public Subscribe(String email, QuestionCategory category) {
         this.email = email;
         this.category = category;
         this.nextQuestionSequence = determineSequenceByCategory(category);
+        this.token = UUID.randomUUID().toString();
+        this.deletedAt = null;
     }
 
     private long determineSequenceByCategory(QuestionCategory category) {
         if (category == QuestionCategory.BACKEND) {
             return 15L;
         }
+
         return 0L;
+    }
+
+    public void unsubscribe() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/maeilmail/subscribe/SubscribeApi.java
+++ b/src/main/java/maeilmail/subscribe/SubscribeApi.java
@@ -2,6 +2,7 @@ package maeilmail.subscribe;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 class SubscribeApi {
 
     private final SubscribeService subscribeService;
+    private final UnsubscribeService unsubscribeService;
 
     @PostMapping("/subscribe/verify/send")
     public ResponseEntity<Void> send(@RequestBody VerifyEmailRequest request) {
@@ -22,6 +24,13 @@ class SubscribeApi {
     @PostMapping("/subscribe")
     public ResponseEntity<Void> subscribe(@RequestBody SubscribeRequest request) {
         subscribeService.subscribe(request);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/subscribe")
+    public ResponseEntity<Void> unsubscribe(@RequestBody UnsubscribeRequest request) {
+        unsubscribeService.unsubscribe(request);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/maeilmail/subscribe/SubscribeRepository.java
+++ b/src/main/java/maeilmail/subscribe/SubscribeRepository.java
@@ -1,5 +1,6 @@
 package maeilmail.subscribe;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -10,22 +11,37 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
-    boolean existsByEmailAndCategory(String email, QuestionCategory category);
+    boolean existsByEmailAndCategoryAndDeletedAtIsNull(String email, QuestionCategory category);
 
-    Optional<Subscribe> findByEmailAndToken(String email, String token);
+    Optional<Subscribe> findByEmailAndTokenAndDeletedAtIsNull(String email, String token);
 
-    @Query("select distinct s.email from Subscribe s")
+    @Query("""
+            select distinct s.email
+            from Subscribe s
+            where s.deletedAt is null
+            """)
     List<String> findDistinctEmails();
 
-    @Query("select distinct s.email from Subscribe s where s.createdAt between :startOfDay and :endOfDay")
+    /**
+     * 주어진 일자의 중복을 제거한 구독자를 조회하는 용도로 사용되므로 논리 삭제는 고려하지 않는다.
+     *
+     * @see maeilmail.statistics.StatisticsService#countNewSubscribersOnSpecificDate(LocalDate)
+     */
+    @Query("""
+            select distinct s.email
+            from Subscribe s
+            where s.createdAt between :startOfDay and :endOfDay
+            """)
     List<String> findDistinctEmailsByCreatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 
-    List<Subscribe> findAllByCreatedAtBefore(LocalDateTime baseDateTime);
+    List<Subscribe> findAllByCreatedAtBeforeAndDeletedAtIsNull(LocalDateTime baseDateTime);
 
     @Query("""
             update Subscribe s
             set s.nextQuestionSequence = s.nextQuestionSequence + 1
-            where s.createdAt < :baseDateTime
+            where
+                s.deletedAt is null and
+                s.createdAt < :baseDateTime
             """)
     @Modifying
     void increaseNextQuestionSequence(LocalDateTime baseDateTime);

--- a/src/main/java/maeilmail/subscribe/SubscribeRepository.java
+++ b/src/main/java/maeilmail/subscribe/SubscribeRepository.java
@@ -2,6 +2,7 @@ package maeilmail.subscribe;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import maeilmail.question.QuestionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,6 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
     boolean existsByEmailAndCategory(String email, QuestionCategory category);
+
+    Optional<Subscribe> findByEmailAndToken(String email, String token);
 
     @Query("select distinct s.email from Subscribe s")
     List<String> findDistinctEmails();

--- a/src/main/java/maeilmail/subscribe/SubscribeService.java
+++ b/src/main/java/maeilmail/subscribe/SubscribeService.java
@@ -10,8 +10,8 @@ import maeilmail.question.QuestionCategory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
 @Slf4j
+@Service
 @RequiredArgsConstructor
 class SubscribeService {
 
@@ -37,7 +37,7 @@ class SubscribeService {
     }
 
     private void subscribeIfAbsent(String email, QuestionCategory category) {
-        boolean alreadyExist = subscribeRepository.existsByEmailAndCategory(email, category);
+        boolean alreadyExist = subscribeRepository.existsByEmailAndCategoryAndDeletedAtIsNull(email, category);
 
         if (!alreadyExist) {
             Subscribe subscribe = new Subscribe(email, category);

--- a/src/main/java/maeilmail/subscribe/UnsubscribeRequest.java
+++ b/src/main/java/maeilmail/subscribe/UnsubscribeRequest.java
@@ -1,0 +1,4 @@
+package maeilmail.subscribe;
+
+record UnsubscribeRequest(String email, String token) {
+}

--- a/src/main/java/maeilmail/subscribe/UnsubscribeService.java
+++ b/src/main/java/maeilmail/subscribe/UnsubscribeService.java
@@ -15,7 +15,7 @@ class UnsubscribeService {
 
     @Transactional
     public void unsubscribe(UnsubscribeRequest request) {
-        Subscribe subscribe = subscribeRepository.findByEmailAndToken(request.email(), request.token())
+        Subscribe subscribe = subscribeRepository.findByEmailAndTokenAndDeletedAtIsNull(request.email(), request.token())
                 .orElseThrow(NoSuchElementException::new);
 
         log.info("구독 해지 요청, 이메일 = {} 구독 분야 = {}", subscribe.getEmail(), subscribe.getCategory().name());

--- a/src/main/java/maeilmail/subscribe/UnsubscribeService.java
+++ b/src/main/java/maeilmail/subscribe/UnsubscribeService.java
@@ -1,0 +1,23 @@
+package maeilmail.subscribe;
+
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+class UnsubscribeService {
+
+    private final SubscribeRepository subscribeRepository;
+
+    @Transactional
+    public void unsubscribe(UnsubscribeRequest request) {
+        Subscribe subscribe = subscribeRepository.findByEmailAndToken(request.email(), request.token())
+                .orElseThrow(NoSuchElementException::new);
+
+        subscribe.unsubscribe();
+    }
+}

--- a/src/main/java/maeilmail/subscribe/UnsubscribeService.java
+++ b/src/main/java/maeilmail/subscribe/UnsubscribeService.java
@@ -18,6 +18,7 @@ class UnsubscribeService {
         Subscribe subscribe = subscribeRepository.findByEmailAndToken(request.email(), request.token())
                 .orElseThrow(NoSuchElementException::new);
 
+        log.info("구독 해지 요청, 이메일 = {} 구독 분야 = {}", subscribe.getEmail(), subscribe.getCategory().name());
         subscribe.unsubscribe();
     }
 }

--- a/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
@@ -33,7 +33,7 @@ class SendQuestionScheduler {
     public void sendMail() {
         log.info("구독자에게 질문지 발송을 시작합니다.");
         LocalDateTime now = ZonedDateTime.now(KOREA_ZONE).toLocalDateTime();
-        List<Subscribe> subscribes = subscribeRepository.findAllByCreatedAtBefore(now);
+        List<Subscribe> subscribes = subscribeRepository.findAllByCreatedAtBeforeAndDeletedAtIsNull(now);
         log.info("{}명의 구독자에게 질문지를 발송합니다. 발송 시각 : {}", subscribes.size(), now);
 
         subscribes.stream()

--- a/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
@@ -47,7 +47,7 @@ class SendQuestionScheduler {
         try {
             QuestionSummary questionSummary = choiceQuestionPolicy.choice(subscribe, LocalDate.now());
             String subject = createSubject(questionSummary);
-            String text = createText(questionSummary);
+            String text = createText(subscribe, questionSummary);
             return new SubscribeQuestionMessage(subscribe, questionSummary.toQuestion(), subject, text);
         } catch (Exception e) {
             log.info("면접 질문 선택 실패 = {}", e.getMessage());
@@ -63,10 +63,12 @@ class SendQuestionScheduler {
         return question.customizedTitle();
     }
 
-    private String createText(QuestionSummary question) {
+    private String createText(Subscribe subscribe, QuestionSummary question) {
         HashMap<Object, Object> attribute = new HashMap<>();
         attribute.put("questionId", question.id());
         attribute.put("question", question.title());
+        attribute.put("email", subscribe.getEmail());
+        attribute.put("token", subscribe.getToken());
 
         return subscribeQuestionView.render(attribute);
     }

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
@@ -39,6 +39,7 @@ public class SubscribeQuestionQueryService {
                         .and(subscribe.deletedAt.isNull())
                         .and(eqCategory(category))
                         .and(subscribeQuestion.isSuccess));
+
         JPAQuery<QuestionSummary> resultQuery = queryFactory.select(projectionQuestionSummary())
                 .from(subscribeQuestion)
                 .join(subscribe).on(subscribeQuestion.subscribe.eq(subscribe))

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
@@ -36,6 +36,7 @@ public class SubscribeQuestionQueryService {
                 .from(subscribeQuestion)
                 .join(subscribe).on(subscribeQuestion.subscribe.eq(subscribe))
                 .where(eqEmail(email)
+                        .and(subscribe.deletedAt.isNull())
                         .and(eqCategory(category))
                         .and(subscribeQuestion.isSuccess));
         JPAQuery<QuestionSummary> resultQuery = queryFactory.select(projectionQuestionSummary())
@@ -43,6 +44,7 @@ public class SubscribeQuestionQueryService {
                 .join(subscribe).on(subscribeQuestion.subscribe.eq(subscribe))
                 .join(question).on(subscribeQuestion.question.eq(question))
                 .where(eqEmail(email)
+                        .and(subscribe.deletedAt.isNull())
                         .and(eqCategory(category))
                         .and(subscribeQuestion.isSuccess))
                 .offset(pageable.getOffset())

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionView.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionView.java
@@ -16,8 +16,7 @@ class SubscribeQuestionView implements MailView {
     @Override
     public String render(Map<Object, Object> attribute) {
         Context context = new Context();
-        context.setVariable("questionId", attribute.get("questionId"));
-        context.setVariable("question", attribute.get("question"));
+        attribute.forEach((key, value) -> context.setVariable(key.toString(), value.toString()));
 
         return templateEngine.process("question-v3", context);
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -21,11 +21,10 @@ values ('백엔드 질문 1',
         '프론트 질문 3 내용',
         'FRONTEND');
 
-insert into subscribe(email, category, next_question_sequence)
-values ('leehaneul990623@gmail.com', 'BACKEND', 0),
-       ('leehaneul0623@gmail.com', 'FRONTEND', 0),
-       ('gosmdochee@gmail.com', 'BACKEND', 0)
-;
+insert into subscribe(email, category, next_question_sequence, token, created_at)
+values ('leehaneul990623@gmail.com', 'BACKEND', 0, 'test-token-1', '2024-11-01'),
+       ('leehaneul0623@gmail.com', 'FRONTEND', 0, 'test-token-2', '2024-11-01'),
+       ('gosmdochee@gmail.com', 'BACKEND', 0, 'test-token-3', '2024-11-01');
 
 insert into admin(email)
 values ('leehaneul990623@gmail.com'),
@@ -35,4 +34,4 @@ insert into subscribe_question(subscribe_id, question_id, is_success)
 values (3, 2, true),
        (3, 7, true),
        (3, 1, false),
-       (3, 5, true)
+       (3, 5, true);

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -15,9 +15,11 @@ create table subscribe
     id                     bigint auto_increment,
     email                  varchar(255) not null,
     category               enum ('BACKEND','FRONTEND') not null,
+    next_question_sequence bigint       not null default '0',
+    token                  varchar(255) not null unique,
     created_at             timestamp(6),
     updated_at             timestamp(6),
-    next_question_sequence bigint       not null default '0',
+    deleted_at             timestamp(6),
     primary key (id)
 );
 
@@ -58,5 +60,7 @@ create table subscribe_question
     question_id  bigint,
     subscribe_id bigint,
     is_success   boolean not null,
+    created_at   timestamp(6),
+    updated_at   timestamp(6),
     primary key (id)
 );

--- a/src/main/resources/templates/question-v3.html
+++ b/src/main/resources/templates/question-v3.html
@@ -22,14 +22,14 @@
       &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy;
       &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
       &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy;
-              &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
+      &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
       &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj;
       &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy;
       &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
       &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy;
       &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
       &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy;
-              &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
+      &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
       &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj;
       &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy;
       &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp;
@@ -42,6 +42,7 @@
       &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy; &zwnj; &nbsp; &shy;
     </span>
 </section>
+
 <div style="
         height: 100%;
         width: 100%;
@@ -58,6 +59,7 @@
           width: 100%;
           margin: 0 auto;
         ">
+
         <a href="https://www.maeil-mail.kr/" style="
             display: block;
             margin-bottom: 40px;
@@ -78,7 +80,7 @@
           ">
             <p style="
               font-size: 22px;
-              color: &quot;#2b2b2b&quot;;
+              color: #2b2b2b;
               font-weight: bold;
               line-height: 1.5;
             " th:text="${question}">
@@ -96,20 +98,75 @@
             아래 버튼을 눌러 답변을 확인해 보시길 권장드려요!
         </p>
         <a th:href="@{https://www.maeil-mail.kr/question/{id}(id = ${questionId})}" style="
-            display: inline-block;
-            padding: 15px 35px;
-            background-color: #00a86b;
-            color: white;
-            text-decoration: none;
-            border-radius: 30px;
-            font-size: 18px;
-            font-weight: 600;
-            cursor: pointer;
-
-            transition: transform 0.4s ease-in-out;
-          " onmouseover="this.style.transform='scale(1.03)';" onmouseout="this.style.transform='scale(1)';">
+              display: inline-block;
+              padding: 15px 35px;
+              background-color: #00a86b;
+              color: white;
+              text-decoration: none;
+              border-radius: 30px;
+              font-size: 18px;
+              font-weight: 600;
+              cursor: pointer;
+            ">
             답변 확인
         </a>
+        <table role="presentation" style="width: 100%; border-collapse: collapse;">
+            <tr style="height: 5rem"></tr>
+            <tr>
+                <td align="right"
+                    style="margin-top: 5rem; font-size: 12px; padding-left: 1rem; color: #888888; width: auto; white-space: nowrap;">
+                    <a th:href="@{https://www.maeil-mail.kr/question/mine/{email}(email = ${email})}" style="
+              color: #888888;
+              text-decoration: none;
+              ">
+                        <div style="
+              display: inline;
+                cursor: pointer;
+                text-decoration: underline;
+                text-underline-offset: 3px;
+                text-decoration-thickness: 0.3px;
+                ">
+                            📮 질문 모아보기
+                        </div>
+                    </a>
+                    &nbsp;
+                    <span>|</span>
+                    &nbsp;
+                    <a style="
+            color: #888888;
+            text-decoration: none;
+            " href="https://forms.gle/8AqXv4kBqiBVVQMk8" target="_blank">
+                        <div style="
+              display: inline;
+              cursor: pointer;
+              text-decoration: underline;
+              text-underline-offset: 3px;
+              text-decoration-thickness: 0.3px;
+              ">
+                            피드백하기
+                        </div>
+                    </a>
+                    &nbsp;
+                    <span>|</span>
+                    &nbsp;
+                    <a th:href="@{https://www.maeil-mail.kr/unsubscribe(email=${email}, token=${token})}"
+                       target="_blank" style="
+            color: #888888;
+            text-decoration: none;
+            ">
+                        <div style="
+              display: inline;
+              cursor: pointer;
+              text-decoration: underline;
+              text-underline-offset: 3px;
+              text-decoration-thickness: 0.3px;
+              ">
+                            구독해지
+                        </div>
+                    </a>
+                </td>
+            </tr>
+        </table>
     </div>
 </div>
 </body>

--- a/src/test/java/maeilmail/subscribe/SubscribeRepositoryTest.java
+++ b/src/test/java/maeilmail/subscribe/SubscribeRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import maeilmail.question.QuestionCategory;
@@ -43,12 +44,13 @@ class SubscribeRepositoryTest extends IntegrationTestSupport {
             QuestionCategory category,
             LocalDateTime createdAt
     ) {
-        String sql = "insert into subscribe(email, category, next_question_sequence, created_at) values(?, ?, ?, ?);";
+        String sql = "insert into subscribe(email, category, next_question_sequence, created_at, token) values(?, ?, ?, ?, ?);";
         Query nativeQuery = entityManager.createNativeQuery(sql);
         nativeQuery.setParameter(1, email);
         nativeQuery.setParameter(2, category.toLowerCase());
         nativeQuery.setParameter(3, 0);
         nativeQuery.setParameter(4, createdAt);
+        nativeQuery.setParameter(5, UUID.randomUUID().toString());
         nativeQuery.executeUpdate();
     }
 }

--- a/src/test/java/maeilmail/subscribe/UnsubscribeServiceTest.java
+++ b/src/test/java/maeilmail/subscribe/UnsubscribeServiceTest.java
@@ -1,0 +1,47 @@
+package maeilmail.subscribe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.NoSuchElementException;
+import maeilmail.question.QuestionCategory;
+import maeilmail.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class UnsubscribeServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UnsubscribeService unsubscribeService;
+
+    @Autowired
+    private SubscribeRepository subscribeRepository;
+
+    @Test
+    @DisplayName("존재하지 않는 구독자를 해지할 수 없다.")
+    void unknownSubscribe() {
+        UnsubscribeRequest request = new UnsubscribeRequest("unknown@test.com", "unknown-token");
+
+        assertThatThrownBy(() -> unsubscribeService.unsubscribe(request))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    @DisplayName("구독을 해지할 수 있다.")
+    void unsubscribe() {
+        Subscribe subscribe = createSubscribe();
+        UnsubscribeRequest request = new UnsubscribeRequest(subscribe.getEmail(), subscribe.getToken());
+
+        unsubscribeService.unsubscribe(request);
+
+        assertThat(subscribe.getDeletedAt()).isNotNull();
+
+    }
+
+    private Subscribe createSubscribe() {
+        Subscribe subscribe = new Subscribe("email@test.com", QuestionCategory.BACKEND);
+
+        return subscribeRepository.save(subscribe);
+    }
+}


### PR DESCRIPTION
- close #107 
- 구독 해지 기능을 구현했습니다. 논리 삭제를 도입한 근거는 특정 날짜에 구독 해지자를 조회해야한다는 요구사항이 있기 때문입니다.
- subscribe question 도메인 쿼리 서비스에서 is null 쿼리를 추가했습니다.
- 이외에 다른 subscribe 관련 쿼리에 논리 삭제를 대응했습니다.
- token 컬럼이 신규로 필요하게 되어서 다음과 같이 대응할 예정입니다. (not null, unique이기 때문에 잠시 구독 신청이 불가능해짐)
    1. not null을 걸고, default를 ""로 설정한다.
    2. 전체 토큰을 로컬에서 설정한다.
    3. 서버를 배포한다.
    4. 배포 과정 중 생성된 구독자의 토큰을 로컬에서 설정한다.
    5. unique 제약을 추가한다.