### PR TITLE
중복 코드와 미사용 코드를 제거한다.

### DIFF
--- a/src/main/java/maeilmail/AbstractMailSender.java
+++ b/src/main/java/maeilmail/AbstractMailSender.java
@@ -1,0 +1,49 @@
+package maeilmail;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractMailSender<T> {
+
+    private static final int MAIL_SENDER_RATE_MILLISECONDS = 500;
+    protected static final String FROM_EMAIL = "maeil-mail <maeil-mail-noreply@maeil-mail.site>";
+
+    protected final JavaMailSender javaMailSender;
+
+    @Async
+    public void sendMail(T message) {
+        try {
+            logSending(message);
+            MimeMessage mimeMessage = createMimeMessage(message);
+            javaMailSender.send(mimeMessage);
+            handleSuccess(message);
+        } catch (MessagingException | MailException e) {
+            log.error("메일 전송 실패: {}", e.getMessage(), e);
+            handleFailure(message);
+        } catch (Exception e) {
+            log.error("예기치 않은 오류 발생: {}", e.getMessage(), e);
+            handleFailure(message);
+        } finally {
+            try {
+                Thread.sleep(MAIL_SENDER_RATE_MILLISECONDS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    protected abstract void logSending(T message);
+
+    protected abstract MimeMessage createMimeMessage(T message) throws MessagingException;
+
+    protected abstract void handleSuccess(T message);
+
+    protected abstract void handleFailure(T message);
+}

--- a/src/main/java/maeilmail/mail/AbstractMailSender.java
+++ b/src/main/java/maeilmail/mail/AbstractMailSender.java
@@ -1,4 +1,4 @@
-package maeilmail;
+package maeilmail.mail;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;

--- a/src/main/java/maeilmail/mail/MailSender.java
+++ b/src/main/java/maeilmail/mail/MailSender.java
@@ -3,7 +3,6 @@ package maeilmail.mail;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
-import maeilmail.AbstractMailSender;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;

--- a/src/main/java/maeilmail/subscribequestion/QuestionSender.java
+++ b/src/main/java/maeilmail/subscribequestion/QuestionSender.java
@@ -2,70 +2,58 @@ package maeilmail.subscribequestion;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maeilmail.AbstractMailSender;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionCategory;
 import maeilmail.subscribe.Subscribe;
-import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component(value = "questionSender")
-@RequiredArgsConstructor
-public class QuestionSender {
+@Component("questionSender")
+public class QuestionSender extends AbstractMailSender<SubscribeQuestionMessage> {
 
-    private static final int MAIL_SENDER_RATE_MILLISECONDS = 500;
-    private static final String FROM_EMAIL = "maeil-mail <maeil-mail-noreply@maeil-mail.site>";
-
-    private final JavaMailSender javaMailSender;
     private final SubscribeQuestionRepository subscribeQuestionRepository;
 
-    @Async
-    public void sendMail(SubscribeQuestionMessage message) {
-        Subscribe subscribe = message.subscribe();
-        Question question = message.question();
-        QuestionCategory questionCategory = question.getCategory();
-
-        String to = subscribe.getEmail();
-        String subject = "[매일메일] " + message.subject();
-        String text = message.text();
-        String category = questionCategory.toLowerCase();
-        try {
-            log.info("질문지를 전송합니다. email = {}, questionId = {}, subject = {}, category = {}", to, question.getId(), subject, category);
-            MimeMessage mimeMessage = convertToMime(to, subject, text);
-            javaMailSender.send(mimeMessage);
-            subscribeQuestionRepository.save(SubscribeQuestion.success(subscribe, question));
-        } catch (MessagingException | MailException e) {
-            log.error("메일 전송 실패: email = {}, questionId = {}, subject = {}, category = {}, 오류 = {}", to, question.getId(), subject, category.toLowerCase(), e.getMessage(), e);
-            subscribeQuestionRepository.save(SubscribeQuestion.fail(subscribe, question));
-        } catch (Exception e) {
-            log.error("예기치 않은 오류 발생: email = {}, questionId = {}, subject = {}, category = {}, 오류 = {}", to, question.getId(), subject, category.toLowerCase(), e.getMessage(), e);
-            subscribeQuestionRepository.save(SubscribeQuestion.fail(subscribe, question));
-        } finally {
-            try {
-                Thread.sleep(MAIL_SENDER_RATE_MILLISECONDS);
-            } catch (InterruptedException ignored) {
-            }
-        }
+    public QuestionSender(JavaMailSender javaMailSender, SubscribeQuestionRepository subscribeQuestionRepository) {
+        super(javaMailSender);
+        this.subscribeQuestionRepository = subscribeQuestionRepository;
     }
 
-    private MimeMessage convertToMime(String to, String subject, String text) throws MessagingException {
+    @Override
+    protected void logSending(SubscribeQuestionMessage message) {
+        Subscribe subscribe = message.subscribe();
+        Question question = message.question();
+        QuestionCategory category = question.getCategory();
+        log.info("질문지를 전송합니다. email = {}, questionId = {}, subject = {}, category = {}",
+                subscribe.getEmail(), question.getId(), message.subject(), category.toLowerCase());
+    }
+
+    @Override
+    protected MimeMessage createMimeMessage(SubscribeQuestionMessage message) throws MessagingException {
+        Subscribe subscribe = message.subscribe();
+
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        tryAppendOpenEventTrace(mimeMessage);
-        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-        mimeMessageHelper.setFrom(FROM_EMAIL);
-        mimeMessageHelper.setTo(to);
-        mimeMessageHelper.setSubject(subject);
-        mimeMessageHelper.setText(text, true);
+        mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
+        mimeMessage.setHeader("X-SES-MESSAGE-TAGS", "mail-open");
+
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        helper.setFrom(FROM_EMAIL);
+        helper.setTo(subscribe.getEmail());
+        helper.setSubject("[매일메일] " + message.subject());
+        helper.setText(message.text(), true);
         return mimeMessage;
     }
 
-    private void tryAppendOpenEventTrace(MimeMessage mimeMessage) throws MessagingException {
-        mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
-        mimeMessage.setHeader("X-SES-MESSAGE_TAGS", "mail-open");
+    @Override
+    protected void handleSuccess(SubscribeQuestionMessage message) {
+        subscribeQuestionRepository.save(SubscribeQuestion.success(message.subscribe(), message.question()));
+    }
+
+    @Override
+    protected void handleFailure(SubscribeQuestionMessage message) {
+        subscribeQuestionRepository.save(SubscribeQuestion.fail(message.subscribe(), message.question()));
     }
 }

--- a/src/main/java/maeilmail/subscribequestion/QuestionSender.java
+++ b/src/main/java/maeilmail/subscribequestion/QuestionSender.java
@@ -3,7 +3,7 @@ package maeilmail.subscribequestion;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
-import maeilmail.AbstractMailSender;
+import maeilmail.mail.AbstractMailSender;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionCategory;
 import maeilmail.subscribe.Subscribe;


### PR DESCRIPTION
`MailMessage`, `SubscribeQuestionMessage` 레코드 타입이 달라서 FunctionalInterface 만으로 중복을 제거할 수 없었습니다.
그래서 `AbstractMailSender` 추상클래스를 만들어서 템플릿 메서드 패턴으로 `MailSender`, `QuestionSender` 클래스의 중복 코드를 제거했습니다.