### PR TITLE
구독질문지 필요한 컬럼만 프로젝션한다.

### DIFF
--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionApi.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionApi.java
@@ -2,7 +2,6 @@ package maeilmail.subscribequestion;
 
 import lombok.RequiredArgsConstructor;
 import maeilmail.PaginationResponse;
-import maeilmail.question.QuestionSummary;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +16,12 @@ public class SubscribeQuestionApi {
     private final SubscribeQuestionQueryService subscribeQuestionQueryService;
 
     @GetMapping("/subscribe-question")
-    public ResponseEntity<PaginationResponse<QuestionSummary>> getSubscribeQuestion(
+    public ResponseEntity<PaginationResponse<SubscribeQuestionSummary>> getSubscribeQuestion(
             @RequestParam String email,
             @RequestParam(defaultValue = "all") String category,
             @PageableDefault(sort = {"category", "id"}, size = 200) Pageable pageable
     ) {
-        PaginationResponse<QuestionSummary> response = subscribeQuestionQueryService.pageByEmailAndCategory(email, category, pageable);
+        PaginationResponse<SubscribeQuestionSummary> response = subscribeQuestionQueryService.pageByEmailAndCategory(email, category, pageable);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionQueryService.java
@@ -13,10 +13,8 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import maeilmail.PaginationResponse;
-import maeilmail.question.QQuestionSummary;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionCategory;
-import maeilmail.question.QuestionSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -31,7 +29,7 @@ public class SubscribeQuestionQueryService {
 
     private final JPAQueryFactory queryFactory;
 
-    public PaginationResponse<QuestionSummary> pageByEmailAndCategory(String email, String category, Pageable pageable) {
+    public PaginationResponse<SubscribeQuestionSummary> pageByEmailAndCategory(String email, String category, Pageable pageable) {
         JPAQuery<Long> countQuery = queryFactory.select(subscribeQuestion.count())
                 .from(subscribeQuestion)
                 .join(subscribe).on(subscribeQuestion.subscribe.eq(subscribe))
@@ -40,7 +38,7 @@ public class SubscribeQuestionQueryService {
                         .and(eqCategory(category))
                         .and(subscribeQuestion.isSuccess));
 
-        JPAQuery<QuestionSummary> resultQuery = queryFactory.select(projectionQuestionSummary())
+        JPAQuery<SubscribeQuestionSummary> resultQuery = queryFactory.select(projectionSubscribeQuestionSummary())
                 .from(subscribeQuestion)
                 .join(subscribe).on(subscribeQuestion.subscribe.eq(subscribe))
                 .join(question).on(subscribeQuestion.question.eq(question))
@@ -53,7 +51,7 @@ public class SubscribeQuestionQueryService {
 
         appendOrderCondition(pageable, resultQuery);
 
-        Page<QuestionSummary> pageResult = PageableExecutionUtils.getPage(resultQuery.fetch(), pageable, countQuery::fetchOne);
+        Page<SubscribeQuestionSummary> pageResult = PageableExecutionUtils.getPage(resultQuery.fetch(), pageable, countQuery::fetchOne);
         return new PaginationResponse<>(pageResult.isLast(), (long) pageResult.getTotalPages(), pageResult.getContent());
     }
 
@@ -69,7 +67,7 @@ public class SubscribeQuestionQueryService {
         return question.category.eq(QuestionCategory.from(category));
     }
 
-    private void appendOrderCondition(Pageable pageable, JPAQuery<QuestionSummary> resultQuery) {
+    private void appendOrderCondition(Pageable pageable, JPAQuery<SubscribeQuestionSummary> resultQuery) {
         for (Sort.Order order : pageable.getSort()) {
             PathBuilder<Question> entityPath = new PathBuilder<>(question.getType(), question.getMetadata());
             Expression orderExpression = entityPath.get(order.getProperty());
@@ -78,11 +76,10 @@ public class SubscribeQuestionQueryService {
         }
     }
 
-    private QQuestionSummary projectionQuestionSummary() {
-        return new QQuestionSummary(
+    private QSubscribeQuestionSummary projectionSubscribeQuestionSummary() {
+        return new QSubscribeQuestionSummary(
                 question.id,
                 question.title,
-                question.content,
                 question.customizedTitle,
                 question.category.stringValue().lower()
         );

--- a/src/main/java/maeilmail/subscribequestion/SubscribeQuestionSummary.java
+++ b/src/main/java/maeilmail/subscribequestion/SubscribeQuestionSummary.java
@@ -1,0 +1,10 @@
+package maeilmail.subscribequestion;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record SubscribeQuestionSummary(Long id, String title, String customizedTitle, String category) {
+
+    @QueryProjection
+    public SubscribeQuestionSummary {
+    }
+}

--- a/src/test/java/maeilmail/subscribequestion/SubscribeQuestionApiTest.java
+++ b/src/test/java/maeilmail/subscribequestion/SubscribeQuestionApiTest.java
@@ -40,7 +40,7 @@ class SubscribeQuestionApiTest {
         String email = "test@gmail.com";
         ArgumentCaptor<String> categoryCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        PaginationResponse<QuestionSummary> response = new PaginationResponse<>(true, 0L, Collections.emptyList());
+        PaginationResponse<SubscribeQuestionSummary> response = new PaginationResponse<>(true, 0L, Collections.emptyList());
 
         when(subscribeQuestionQueryService.pageByEmailAndCategory(anyString(), anyString(), any()))
                 .thenReturn(response);

--- a/src/test/java/maeilmail/subscribequestion/SubscribeQuestionQueryServiceTest.java
+++ b/src/test/java/maeilmail/subscribequestion/SubscribeQuestionQueryServiceTest.java
@@ -8,7 +8,6 @@ import maeilmail.PaginationResponse;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionCategory;
 import maeilmail.question.QuestionRepository;
-import maeilmail.question.QuestionSummary;
 import maeilmail.subscribe.Subscribe;
 import maeilmail.subscribe.SubscribeRepository;
 import maeilmail.support.IntegrationTestSupport;
@@ -72,7 +71,7 @@ class SubscribeQuestionQueryServiceTest extends IntegrationTestSupport {
     @DisplayName("구독자의 이메일과 카테고리에 따라 여태까지 받은 모든 질문지를 조회한다.")
     @Test
     void pageByEmailAndCategory() {
-        PaginationResponse<QuestionSummary> response =
+        PaginationResponse<SubscribeQuestionSummary> response =
                 subscribeQuestionQueryService.pageByEmailAndCategory(
                         "111@gmail.com",
                         "backend",
@@ -84,7 +83,7 @@ class SubscribeQuestionQueryServiceTest extends IntegrationTestSupport {
                 () -> assertThat(response.data()).hasSize(2),
                 () -> assertThat(response.totalPage()).isEqualTo(1),
                 () -> assertThat(response.data())
-                        .map(QuestionSummary::title)
+                        .map(SubscribeQuestionSummary::title)
                         .containsExactlyElementsOf(List.of("title-1", "title-2"))
         );
     }
@@ -92,7 +91,7 @@ class SubscribeQuestionQueryServiceTest extends IntegrationTestSupport {
     @DisplayName("카테고리가 all 이면 구독자가 받은 모든 카테고리의 질문을 조회한다.")
     @Test
     void pageByEmailAndDefaultCategory() {
-        PaginationResponse<QuestionSummary> response =
+        PaginationResponse<SubscribeQuestionSummary> response =
                 subscribeQuestionQueryService.pageByEmailAndCategory(
                         "111@gmail.com",
                         "all",
@@ -104,7 +103,7 @@ class SubscribeQuestionQueryServiceTest extends IntegrationTestSupport {
                 () -> assertThat(response.data()).hasSize(3),
                 () -> assertThat(response.totalPage()).isEqualTo(1),
                 () -> assertThat(response.data())
-                        .map(QuestionSummary::title)
+                        .map(SubscribeQuestionSummary::title)
                         .containsExactlyElementsOf(List.of("title-1", "title-2", "title-4"))
         );
     }


### PR DESCRIPTION
구독질문지 API 조회의 응답으로 사용하던 QuestionSummary를 SubscribeQuestionSummary로 변경했습니다.
기존 응답에서 content 데이터가 불필요하여 제거하였습니다.