### PR TITLE
메일 제목을 질문지 제목으로 변경한다. 

### DIFF
--- a/src/main/java/maeilmail/subscribequestion/QuestionSender.java
+++ b/src/main/java/maeilmail/subscribequestion/QuestionSender.java
@@ -37,7 +37,7 @@ public class QuestionSender extends AbstractMailSender<SubscribeQuestionMessage>
 
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
-        mimeMessage.setHeader("X-SES-MESSAGE-TAGS", "mail-open");
+        mimeMessage.setHeader("X-SES-MESSAGE-TAGS", "mail-open=default");
 
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
         helper.setFrom(FROM_EMAIL);

--- a/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
@@ -66,11 +66,7 @@ class SendQuestionScheduler {
     }
 
     private String createSubject(QuestionSummary question) {
-        if (question.customizedTitle() == null) {
-            return "오늘의 면접 질문을 보내드려요.";
-        }
-
-        return question.customizedTitle();
+        return question.title();
     }
 
     private String createText(Subscribe subscribe, QuestionSummary question) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -21,10 +21,10 @@ values ('백엔드 질문 1',
         '프론트 질문 3 내용',
         'FRONTEND');
 
-insert into subscribe(email, category, next_question_sequence, token, created_at)
-values ('leehaneul990623@gmail.com', 'BACKEND', 0, 'test-token-1', '2024-11-01'),
-       ('leehaneul0623@gmail.com', 'FRONTEND', 0, 'test-token-2', '2024-11-01'),
-       ('gosmdochee@gmail.com', 'BACKEND', 0, 'test-token-3', '2024-11-01');
+insert into subscribe(email, category, next_question_sequence, token, created_at, frequency)
+values ('leehaneul990623@gmail.com', 'BACKEND', 0, 'test-token-1', '2024-11-01', 'DAILY'),
+       ('leehaneul0623@gmail.com', 'FRONTEND', 0, 'test-token-2', '2024-11-01', 'DAILY'),
+       ('gosmdochee2@naver.com', 'BACKEND', 0, 'test-token-3', '2024-11-01', 'DAILY');
 
 insert into admin(email)
 values ('leehaneul990623@gmail.com'),


### PR DESCRIPTION
- close: #136 
메일 제목을 질문지와 일치하도록 변경했습니다.
커스터마이즈 제목을 설정하는 기능 자체는 일단 삭제하지 않고
기본 메일 제목의 값 설정 부분만 변경한 상태입니다.
