### PR TITLE
MimeMessage 생성의 책임을 분리한다.

### DIFF
--- a/src/main/java/maeilmail/mail/AbstractMailSender.java
+++ b/src/main/java/maeilmail/mail/AbstractMailSender.java
@@ -10,18 +10,18 @@ import org.springframework.scheduling.annotation.Async;
 
 @Slf4j
 @RequiredArgsConstructor
-public abstract class AbstractMailSender<T> {
+public abstract class AbstractMailSender<T, U extends MimeMessageCreator<T>> {
 
     private static final int MAIL_SENDER_RATE_MILLISECONDS = 500;
-    protected static final String FROM_EMAIL = "maeil-mail <maeil-mail-noreply@maeil-mail.site>";
 
     protected final JavaMailSender javaMailSender;
+    protected final U mimeMessageCreator;
 
     @Async
     public void sendMail(T message) {
         try {
             logSending(message);
-            MimeMessage mimeMessage = createMimeMessage(message);
+            MimeMessage mimeMessage = mimeMessageCreator.createMimeMessage(javaMailSender.createMimeMessage(), message);
             javaMailSender.send(mimeMessage);
             handleSuccess(message);
         } catch (MessagingException | MailException e) {
@@ -40,8 +40,6 @@ public abstract class AbstractMailSender<T> {
     }
 
     protected abstract void logSending(T message);
-
-    protected abstract MimeMessage createMimeMessage(T message) throws MessagingException;
 
     protected abstract void handleSuccess(T message);
 

--- a/src/main/java/maeilmail/mail/MailMimeMessageCreator.java
+++ b/src/main/java/maeilmail/mail/MailMimeMessageCreator.java
@@ -1,0 +1,20 @@
+package maeilmail.mail;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MailMimeMessageCreator extends MimeMessageCreator<MailMessage> {
+
+    @Override
+    public MimeMessage createMimeMessage(MimeMessage mimeMessage, MailMessage message) throws MessagingException {
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        helper.setFrom(FROM_EMAIL);
+        helper.setTo(message.to());
+        helper.setSubject(String.format(TITLE_PREFIX, message.subject()));
+        helper.setText(message.text(), true);
+        return mimeMessage;
+    }
+}

--- a/src/main/java/maeilmail/mail/MailSender.java
+++ b/src/main/java/maeilmail/mail/MailSender.java
@@ -1,37 +1,23 @@
 package maeilmail.mail;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component("emailSender")
-public class MailSender extends AbstractMailSender<MailMessage> {
+public class MailSender extends AbstractMailSender<MailMessage, MailMimeMessageCreator> {
 
     private final MailEventRepository mailEventRepository;
 
-    public MailSender(JavaMailSender javaMailSender, MailEventRepository mailEventRepository) {
-        super(javaMailSender);
+    public MailSender(JavaMailSender javaMailSender, MailMimeMessageCreator mimeMessageCreator, MailEventRepository mailEventRepository) {
+        super(javaMailSender, mimeMessageCreator);
         this.mailEventRepository = mailEventRepository;
     }
 
     @Override
     protected void logSending(MailMessage message) {
         log.info("메일을 전송합니다. email = {} subject = {} type = {}", message.to(), message.subject(), message.type());
-    }
-
-    @Override
-    protected MimeMessage createMimeMessage(MailMessage message) throws MessagingException {
-        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-        helper.setFrom(FROM_EMAIL);
-        helper.setTo(message.to());
-        helper.setSubject("[매일메일] " + message.subject());
-        helper.setText(message.text(), true);
-        return mimeMessage;
     }
 
     @Override

--- a/src/main/java/maeilmail/mail/MimeMessageCreator.java
+++ b/src/main/java/maeilmail/mail/MimeMessageCreator.java
@@ -1,0 +1,12 @@
+package maeilmail.mail;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+public abstract class MimeMessageCreator<T> {
+
+    protected static final String FROM_EMAIL = "maeil-mail <maeil-mail-noreply@maeil-mail.site>";
+    protected static final String TITLE_PREFIX = "[매일메일] %s";
+
+    public abstract MimeMessage createMimeMessage(MimeMessage mimeMessage, T message) throws MessagingException;
+}

--- a/src/main/java/maeilmail/subscribequestion/QuestionMimeMessageCreator.java
+++ b/src/main/java/maeilmail/subscribequestion/QuestionMimeMessageCreator.java
@@ -1,0 +1,27 @@
+package maeilmail.subscribequestion;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import maeilmail.mail.MimeMessageCreator;
+import maeilmail.subscribe.Subscribe;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuestionMimeMessageCreator extends MimeMessageCreator<SubscribeQuestionMessage> {
+
+    @Override
+    public MimeMessage createMimeMessage(MimeMessage mimeMessage, SubscribeQuestionMessage message) throws MessagingException {
+        Subscribe subscribe = message.subscribe();
+
+        mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
+        mimeMessage.setHeader("X-SES-MESSAGE-TAGS", "mail-open=default");
+
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        helper.setFrom(FROM_EMAIL);
+        helper.setTo(subscribe.getEmail());
+        helper.setSubject(String.format(TITLE_PREFIX, message.subject()));
+        helper.setText(message.text(), true);
+        return mimeMessage;
+    }
+}

--- a/src/main/java/maeilmail/subscribequestion/QuestionSender.java
+++ b/src/main/java/maeilmail/subscribequestion/QuestionSender.java
@@ -1,24 +1,21 @@
 package maeilmail.subscribequestion;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
 import maeilmail.mail.AbstractMailSender;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionCategory;
 import maeilmail.subscribe.Subscribe;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component("questionSender")
-public class QuestionSender extends AbstractMailSender<SubscribeQuestionMessage> {
+public class QuestionSender extends AbstractMailSender<SubscribeQuestionMessage, QuestionMimeMessageCreator> {
 
     private final SubscribeQuestionRepository subscribeQuestionRepository;
 
-    public QuestionSender(JavaMailSender javaMailSender, SubscribeQuestionRepository subscribeQuestionRepository) {
-        super(javaMailSender);
+    public QuestionSender(JavaMailSender javaMailSender, QuestionMimeMessageCreator mimeMessageCreator, SubscribeQuestionRepository subscribeQuestionRepository) {
+        super(javaMailSender, mimeMessageCreator);
         this.subscribeQuestionRepository = subscribeQuestionRepository;
     }
 
@@ -29,22 +26,6 @@ public class QuestionSender extends AbstractMailSender<SubscribeQuestionMessage>
         QuestionCategory category = question.getCategory();
         log.info("질문지를 전송합니다. email = {}, questionId = {}, subject = {}, category = {}",
                 subscribe.getEmail(), question.getId(), message.subject(), category.toLowerCase());
-    }
-
-    @Override
-    protected MimeMessage createMimeMessage(SubscribeQuestionMessage message) throws MessagingException {
-        Subscribe subscribe = message.subscribe();
-
-        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
-        mimeMessage.setHeader("X-SES-MESSAGE-TAGS", "mail-open=default");
-
-        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-        helper.setFrom(FROM_EMAIL);
-        helper.setTo(subscribe.getEmail());
-        helper.setSubject("[매일메일] " + message.subject());
-        helper.setText(message.text(), true);
-        return mimeMessage;
     }
 
     @Override

--- a/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribequestion/SendQuestionScheduler.java
@@ -65,7 +65,7 @@ class SendQuestionScheduler {
             String text = createText(subscribe, questionSummary);
             return new SubscribeQuestionMessage(subscribe, questionSummary.toQuestion(), subject, text);
         } catch (Exception e) {
-            log.info("면접 질문 선택 실패 = {}", e.getMessage());
+            log.error("일간 면접 질문 선택 실패. 구독자 id = {}", subscribe.getId(), e);
             return null;
         }
     }

--- a/src/main/java/maeilmail/subscribequestion/SendWeeklyQuestionScheduler.java
+++ b/src/main/java/maeilmail/subscribequestion/SendWeeklyQuestionScheduler.java
@@ -66,7 +66,7 @@ class SendWeeklyQuestionScheduler {
 
             return createWeeklySubscribeQuestionMessage(subscribe, questions, subject, text);
         } catch (Exception e) {
-            log.info("면접 질문 선택 실패 = {}", e.getMessage());
+            log.error("주간 면접 질문 선택 실패. 구독자 id = {}", subscribe.getId(), e);
             return null;
         }
     }

--- a/src/main/java/maeilmail/subscribequestion/WeeklyQuestionMimeMessageCreator.java
+++ b/src/main/java/maeilmail/subscribequestion/WeeklyQuestionMimeMessageCreator.java
@@ -1,0 +1,27 @@
+package maeilmail.subscribequestion;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import maeilmail.mail.MimeMessageCreator;
+import maeilmail.subscribe.Subscribe;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WeeklyQuestionMimeMessageCreator extends MimeMessageCreator<WeeklySubscribeQuestionMessage> {
+
+    @Override
+    public MimeMessage createMimeMessage(MimeMessage mimeMessage, WeeklySubscribeQuestionMessage message) throws MessagingException {
+        Subscribe subscribe = message.subscribe();
+
+        mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
+        mimeMessage.setHeader("X-SES-MESSAGE-TAGS", "mail-open=default");
+
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        helper.setFrom(FROM_EMAIL);
+        helper.setTo(subscribe.getEmail());
+        helper.setSubject(String.format(TITLE_PREFIX, message.subject()));
+        helper.setText(message.text(), true);
+        return mimeMessage;
+    }
+}

--- a/src/main/java/maeilmail/subscribequestion/WeeklyQuestionSender.java
+++ b/src/main/java/maeilmail/subscribequestion/WeeklyQuestionSender.java
@@ -1,25 +1,22 @@
 package maeilmail.subscribequestion;
 
 import java.util.List;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
 import maeilmail.mail.AbstractMailSender;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionCategory;
 import maeilmail.subscribe.Subscribe;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component("weeklyQuestionSender")
-public class WeeklyQuestionSender extends AbstractMailSender<WeeklySubscribeQuestionMessage> {
+public class WeeklyQuestionSender extends AbstractMailSender<WeeklySubscribeQuestionMessage, WeeklyQuestionMimeMessageCreator> {
 
     private final SubscribeQuestionRepository subscribeQuestionRepository;
 
-    public WeeklyQuestionSender(JavaMailSender javaMailSender, SubscribeQuestionRepository subscribeQuestionRepository) {
-        super(javaMailSender);
+    public WeeklyQuestionSender(JavaMailSender javaMailSender, WeeklyQuestionMimeMessageCreator mimeMessageCreator, SubscribeQuestionRepository subscribeQuestionRepository) {
+        super(javaMailSender, mimeMessageCreator);
         this.subscribeQuestionRepository = subscribeQuestionRepository;
     }
 
@@ -33,22 +30,6 @@ public class WeeklyQuestionSender extends AbstractMailSender<WeeklySubscribeQues
 
         log.info("주간 질문지를 전송합니다. email = {}, questionIds = {}, subject = {}, category = {}",
                 subscribe.getEmail(), questions, message.subject(), category.toLowerCase());
-    }
-
-    @Override
-    protected MimeMessage createMimeMessage(WeeklySubscribeQuestionMessage message) throws MessagingException {
-        Subscribe subscribe = message.subscribe();
-
-        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        mimeMessage.setHeader("X-SES-CONFIGURATION-SET", "my-first-configuration-set");
-        mimeMessage.setHeader("X-SES-MESSAGE-TAGS", "mail-open=default");
-
-        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-        helper.setFrom(FROM_EMAIL);
-        helper.setTo(subscribe.getEmail());
-        helper.setSubject("[매일메일] " + message.subject());
-        helper.setText(message.text(), true);
-        return mimeMessage;
     }
 
     @Override

--- a/src/test/java/maeilmail/mail/MailMimeMessageCreatorTest.java
+++ b/src/test/java/maeilmail/mail/MailMimeMessageCreatorTest.java
@@ -1,0 +1,32 @@
+package maeilmail.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+class MailMimeMessageCreatorTest {
+
+    @DisplayName("메일의 MimeMessage를 생성한다.")
+    @Test
+    void createMimeMessage() throws MessagingException {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("localhost");
+        javaMailSender.setPort(25);
+        javaMailSender.setSession(Session.getDefaultInstance(new Properties()));
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MailMessage message = new MailMessage("to", "subject", "text", "type");
+
+        MailMimeMessageCreator creator = new MailMimeMessageCreator();
+
+        MimeMessage result = creator.createMimeMessage(mimeMessage, message);
+
+        assertThat(result.getSubject()).isEqualTo("[매일메일] subject");
+    }
+}

--- a/src/test/java/maeilmail/subscribequestion/QuestionMimeMessageCreatorTest.java
+++ b/src/test/java/maeilmail/subscribequestion/QuestionMimeMessageCreatorTest.java
@@ -1,0 +1,43 @@
+package maeilmail.subscribequestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Properties;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import maeilmail.question.Question;
+import maeilmail.question.QuestionCategory;
+import maeilmail.subscribe.Subscribe;
+import maeilmail.subscribe.SubscribeFrequency;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+class QuestionMimeMessageCreatorTest {
+
+    @DisplayName("일간질문지의 MimeMessage를 생성한다.")
+    @Test
+    void createMimeMessage() throws MessagingException {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("localhost");
+        javaMailSender.setPort(25);
+        javaMailSender.setSession(Session.getDefaultInstance(new Properties()));
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        Subscribe subscribe = new Subscribe("test@test.com", QuestionCategory.BACKEND, SubscribeFrequency.DAILY);
+        Question question = new Question("test1", "content", QuestionCategory.BACKEND);
+        SubscribeQuestionMessage message = new SubscribeQuestionMessage(subscribe, question, "subject", "text");
+
+        QuestionMimeMessageCreator creator = new QuestionMimeMessageCreator();
+
+        MimeMessage result = creator.createMimeMessage(mimeMessage, message);
+
+        assertAll(
+                () -> assertThat(result.getSubject()).isEqualTo("[매일메일] subject"),
+                () -> assertThat(result.getHeader("X-SES-CONFIGURATION-SET")).contains("my-first-configuration-set"),
+                () -> assertThat(result.getHeader("X-SES-MESSAGE-TAGS")).contains("mail-open=default")
+        );
+    }
+}

--- a/src/test/java/maeilmail/subscribequestion/WeeklyQuestionMimeMessageCreatorTest.java
+++ b/src/test/java/maeilmail/subscribequestion/WeeklyQuestionMimeMessageCreatorTest.java
@@ -1,0 +1,43 @@
+package maeilmail.subscribequestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import java.util.Properties;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import maeilmail.question.Question;
+import maeilmail.question.QuestionCategory;
+import maeilmail.subscribe.Subscribe;
+import maeilmail.subscribe.SubscribeFrequency;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+class WeeklyQuestionMimeMessageCreatorTest {
+
+    @DisplayName("주간질문지의 MimeMessage를 생성한다.")
+    @Test
+    void createMimeMessage() throws MessagingException {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("localhost");
+        javaMailSender.setPort(25);
+        javaMailSender.setSession(Session.getDefaultInstance(new Properties()));
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        Subscribe subscribe = new Subscribe("test@test.com", QuestionCategory.BACKEND, SubscribeFrequency.WEEKLY);
+        WeeklySubscribeQuestionMessage message = new WeeklySubscribeQuestionMessage(subscribe, List.of(new Question("test1", "content", QuestionCategory.BACKEND)), "subject", "text");
+
+        WeeklyQuestionMimeMessageCreator creator = new WeeklyQuestionMimeMessageCreator();
+
+        MimeMessage result = creator.createMimeMessage(mimeMessage, message);
+
+        assertAll(
+                () -> assertThat(result.getSubject()).isEqualTo("[매일메일] subject"),
+                () -> assertThat(result.getHeader("X-SES-CONFIGURATION-SET")).contains("my-first-configuration-set"),
+                () -> assertThat(result.getHeader("X-SES-MESSAGE-TAGS")).contains("mail-open=default")
+        );
+    }
+}


### PR DESCRIPTION
- close: #139 

AbstractMailSender의 sendMail 메서드에서 MimeMessage를 생성하는 로직이 중복되어 객체로 분리했습니다.
추상 클래스인 AbstractMailSender를 구현하는 구현체는 MailSender, QuestionSender, WeeklyQuestionSender 세 개가 있었고,
각각의 Sender에서 생성하는 MimeMessage가 모두 각각의 이유로 달라질 수 있기 때문에 
추상 클래스인 MimeMessageCreator를 상속받도록 했습니다.

AbstractMailSender 클래스는 제네릭 타입으로 Message 타입만 사용하고 있었는데, 
MimeMessageCreator를 상속하는 타입을 추가로 가지게 변경됐습니다. 🫠