### PR TITLE
테스트 코드를 개선한다.

### DIFF
--- a/src/main/java/maeilmail/question/QuestionApi.java
+++ b/src/main/java/maeilmail/question/QuestionApi.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-class QuestionApi {
+public class QuestionApi {
 
     private final QuestionQueryService questionQueryService;
 

--- a/src/test/java/maeilmail/question/QuestionApiTest.java
+++ b/src/test/java/maeilmail/question/QuestionApiTest.java
@@ -11,24 +11,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Collections;
+import maeilmail.support.ApiTestSupport;
 import maeilmail.support.PaginationResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(QuestionApi.class)
-class QuestionApiTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private QuestionQueryService questionQueryService;
+class QuestionApiTest extends ApiTestSupport {
 
     @Test
     @DisplayName("페이징 처리된 질문지를 조회할때 기본 값은 page = 0, pageSize = 10, category = 'all' 이다.")

--- a/src/test/java/maeilmail/subscribe/api/SubscribeQuestionApiTest.java
+++ b/src/test/java/maeilmail/subscribe/api/SubscribeQuestionApiTest.java
@@ -12,26 +12,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Collections;
-import maeilmail.subscribe.query.SubscribeQuestionQueryService;
 import maeilmail.subscribe.query.SubscribeQuestionSummary;
+import maeilmail.support.ApiTestSupport;
 import maeilmail.support.PaginationResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(SubscribeQuestionApi.class)
-class SubscribeQuestionApiTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private SubscribeQuestionQueryService subscribeQuestionQueryService;
+class SubscribeQuestionApiTest extends ApiTestSupport {
 
     @Test
     @DisplayName("페이징 처리된 질문지를 조회할때 기본 값은 page = 0, pageSize = 10, category = 'all' 이다.")

--- a/src/test/java/maeilmail/support/ApiTestSupport.java
+++ b/src/test/java/maeilmail/support/ApiTestSupport.java
@@ -1,0 +1,23 @@
+package maeilmail.support;
+
+import maeilmail.question.QuestionApi;
+import maeilmail.question.QuestionQueryService;
+import maeilmail.subscribe.api.SubscribeQuestionApi;
+import maeilmail.subscribe.query.SubscribeQuestionQueryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {SubscribeQuestionApi.class, QuestionApi.class})
+public abstract class ApiTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockBean
+    protected QuestionQueryService questionQueryService;
+
+    @MockBean
+    protected SubscribeQuestionQueryService subscribeQuestionQueryService;
+}


### PR DESCRIPTION
- close #160 
- api 테스팅을 위한 스프링 컨텍스트를 통합했습니다.
- SubscribeRepository 테스트의 sql 의존을 제거했습니다.