### PR TITLE
인증 및 회원가입 기능을 구현한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ subprojects {
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     }
 
     repositories {

--- a/maeil-mail/src/main/resources/application-local.yml
+++ b/maeil-mail/src/main/resources/application-local.yml
@@ -2,6 +2,9 @@ server:
   shutdown: graceful
 
 spring:
+  config:
+    import:
+      - application-local-wiki.yml
   lifecycle:
     timeout-per-shutdown-phase: 30s
   datasource:

--- a/maeil-mail/src/main/resources/application-prod.yml
+++ b/maeil-mail/src/main/resources/application-prod.yml
@@ -2,6 +2,9 @@ server:
   shutdown: graceful
 
 spring:
+  config:
+    import:
+      - application-prod-wiki.yml
   lifecycle:
     timeout-per-shutdown-phase: 30s
   datasource:

--- a/maeil-mail/src/test/resources/application.yml
+++ b/maeil-mail/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    import:
+      - application-local-wiki.yml
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/maeil-wiki/build.gradle
+++ b/maeil-wiki/build.gradle
@@ -2,5 +2,8 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation project(':maeil-support')
 }

--- a/maeil-wiki/src/main/java/maeilwiki/WikiConfiguration.java
+++ b/maeil-wiki/src/main/java/maeilwiki/WikiConfiguration.java
@@ -1,11 +1,13 @@
 package maeilwiki;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ComponentScan
 @EnableAutoConfiguration
+@ConfigurationPropertiesScan
 public class WikiConfiguration {
 }

--- a/maeil-wiki/src/main/java/maeilwiki/comment/CommentService.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/CommentService.java
@@ -25,6 +25,7 @@ public class CommentService {
     public void comment(CommentRequest request, Long wikiId) {
         String uuid = UUID.randomUUID().toString();
         Member temporalMember = new Member(uuid, uuid, "GITHUB");
+        temporalMember.setRefreshToken("temp");
         memberRepository.save(temporalMember);
         Comment comment = request.toComment(temporalMember, wikiId);
 

--- a/maeil-wiki/src/main/java/maeilwiki/comment/CommentService.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/CommentService.java
@@ -58,6 +58,7 @@ public class CommentService {
         if (member == null) {
             String uuid = UUID.randomUUID().toString();
             Member newMember = new Member(uuid, uuid, "GITHUB");
+            newMember.setRefreshToken("refresh");
             memberRepository.save(newMember);
             transactionTmpMemberMap.put(key, newMember);
             return newMember;

--- a/maeil-wiki/src/main/java/maeilwiki/member/Member.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/Member.java
@@ -1,7 +1,6 @@
 package maeilwiki.member;
 
 import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,6 +11,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import maeilsupport.BaseEntity;
 
 @Entity
@@ -35,15 +35,30 @@ public class Member extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private Provider provider;
 
+    @Column(nullable = true)
     private String profileImageUrl;
 
+    @Setter
+    @Column(nullable = false)
+    private String refreshToken;
+
+    @Column(nullable = true)
     private LocalDateTime deletedAt;
 
     public Member(String name, String providerId, String provider) {
+        this(name, providerId, Provider.from(provider), null);
+    }
+
+    public Member(String name, String providerId, String provider, String providerImageUrl) {
+        this(name, providerId, Provider.from(provider), providerImageUrl);
+    }
+
+    public Member(String name, String providerId, Provider provider, String profileImageUrl) {
         validateName(name);
         this.name = name;
         this.providerId = providerId;
-        this.provider = Provider.from(provider);
+        this.provider = provider;
+        this.profileImageUrl = profileImageUrl;
     }
 
     private void validateName(String name) {

--- a/maeil-wiki/src/main/java/maeilwiki/member/Member.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/Member.java
@@ -35,12 +35,12 @@ public class Member extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private Provider provider;
 
-    @Column(nullable = true)
-    private String profileImageUrl;
-
     @Setter
     @Column(nullable = false)
     private String refreshToken;
+
+    @Column(nullable = true)
+    private String profileImageUrl;
 
     @Column(nullable = true)
     private LocalDateTime deletedAt;

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberApi.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberApi.java
@@ -1,0 +1,21 @@
+package maeilwiki.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+class MemberApi {
+
+    private final MemberService memberService;
+
+    @PostMapping("/member")
+    public ResponseEntity<MemberTokenResponse> createMember(@RequestBody MemberRequest request) {
+        MemberTokenResponse response = memberService.apply(request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberRepository.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberRepository.java
@@ -1,6 +1,9 @@
 package maeilwiki.member;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByProviderId(String providerId);
 }

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberRequest.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberRequest.java
@@ -1,0 +1,4 @@
+package maeilwiki.member;
+
+record MemberRequest(String accessToken, String clientSecret) {
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberService.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberService.java
@@ -1,0 +1,64 @@
+package maeilwiki.member;
+
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import maeilwiki.member.github.GithubMemberFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+class MemberService {
+
+    private final MemberTokenGenerator memberTokenGenerator;
+    private final GithubMemberFactory memberFactory;
+    private final MemberRepository memberRepository;
+
+    @Value("${client.secret}")
+    private String clientSecret;
+
+    @Transactional
+    public MemberTokenResponse apply(MemberRequest request) {
+        validateClientSecret(request.clientSecret());
+        Member candidateMember = memberFactory.create(request.accessToken());
+        Member actualMember = trySignInOrSignUp(candidateMember);
+
+        return generateTokenResponse(actualMember);
+    }
+
+    private void validateClientSecret(String clientSecret) {
+        if (!this.clientSecret.equals(clientSecret)) {
+            throw new IllegalArgumentException("올바른 클라이언트 암호를 입력해주세요.");
+        }
+    }
+
+    private Member trySignInOrSignUp(Member candidateMember) {
+        return memberRepository
+                .findByProviderId(candidateMember.getProviderId())
+                .map(this::changeRefreshToken)
+                .orElseGet(signUp(candidateMember));
+    }
+
+    private Member changeRefreshToken(Member existingMember) {
+        existingMember.setRefreshToken(memberTokenGenerator.generateRefreshToken());
+
+        return existingMember;
+    }
+
+    private Supplier<Member> signUp(Member candidateMember) {
+        return () -> {
+            candidateMember.setRefreshToken(memberTokenGenerator.generateRefreshToken());
+            memberRepository.save(candidateMember);
+
+            return candidateMember;
+        };
+    }
+
+    private MemberTokenResponse generateTokenResponse(Member actualMember) {
+        String accessToken = memberTokenGenerator.generateAccessToken(actualMember);
+        String refreshToken = actualMember.getRefreshToken();
+
+        return new MemberTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberService.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberService.java
@@ -12,8 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 class MemberService {
 
     private final MemberTokenGenerator memberTokenGenerator;
-    private final GithubMemberFactory memberFactory;
     private final MemberRepository memberRepository;
+    private final GithubMemberFactory memberFactory;
 
     @Value("${client.secret}")
     private String clientSecret;

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberTokenGenerator.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberTokenGenerator.java
@@ -1,0 +1,41 @@
+package maeilwiki.member;
+
+import java.time.Duration;
+import java.util.Date;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class MemberTokenGenerator {
+
+    private final MemberTokenProperties properties;
+
+    public String generateAccessToken(Member member) {
+        Date date = new Date();
+        Duration accessExpTime = properties.accessExpTime();
+        Date expiration = Date.from(date.toInstant().plus(accessExpTime));
+
+        return Jwts.builder()
+                .subject(member.getId().toString())
+                .issuedAt(date)
+                .expiration(expiration)
+                .claim("picture", member.getProfileImageUrl())
+                .claim("name", member.getName())
+                .signWith(properties.secretKey())
+                .compact();
+    }
+
+    public String generateRefreshToken() {
+        Date date = new Date();
+        Duration refreshExpTime = properties.refreshExpTime();
+        Date expiration = Date.from(date.toInstant().plus(refreshExpTime));
+
+        return Jwts.builder()
+                .issuedAt(date)
+                .expiration(expiration)
+                .signWith(properties.secretKey())
+                .compact();
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberTokenProperties.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberTokenProperties.java
@@ -1,0 +1,17 @@
+package maeilwiki.member;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
+
+@ConfigurationProperties(prefix = "token")
+public record MemberTokenProperties(SecretKey secretKey, Duration accessExpTime, Duration refreshExpTime) {
+
+    @ConstructorBinding
+    public MemberTokenProperties(String secretKey, Duration accessExpTime, Duration refreshExpTime) {
+        this(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), accessExpTime, refreshExpTime);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/MemberTokenResponse.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/MemberTokenResponse.java
@@ -1,0 +1,4 @@
+package maeilwiki.member;
+
+record MemberTokenResponse(String accessToken, String refreshToken) {
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/Provider.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/Provider.java
@@ -2,10 +2,18 @@ package maeilwiki.member;
 
 import java.util.Arrays;
 import java.util.NoSuchElementException;
+import lombok.Getter;
 
+@Getter
 public enum Provider {
 
-    GITHUB;
+    GITHUB("GH-%s");
+
+    private final String providerIdPrefix;
+
+    Provider(String providerIdPrefix) {
+        this.providerIdPrefix = providerIdPrefix;
+    }
 
     public static Provider from(String provider) {
         return Arrays.stream(Provider.values())

--- a/maeil-wiki/src/main/java/maeilwiki/member/github/GithubClient.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/github/GithubClient.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
-class GithubClient {
+public class GithubClient {
 
     private static final int CONNECT_TIMEOUT = 3;
     private static final int READ_TIMEOUT = 10;

--- a/maeil-wiki/src/main/java/maeilwiki/member/github/GithubClient.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/github/GithubClient.java
@@ -1,0 +1,53 @@
+package maeilwiki.member.github;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.ClientHttpRequestFactories;
+import org.springframework.boot.web.client.ClientHttpRequestFactorySettings;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+class GithubClient {
+
+    private static final int CONNECT_TIMEOUT = 3;
+    private static final int READ_TIMEOUT = 10;
+
+    private final RestClient restClient;
+
+    public GithubClient() {
+        this.restClient = createRestClient(RestClient.builder());
+    }
+
+    private RestClient createRestClient(RestClient.Builder restClientBuilder) {
+        return restClientBuilder.requestFactory(clientHttpRequestFactory()).build();
+    }
+
+    private ClientHttpRequestFactory clientHttpRequestFactory() {
+        ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.DEFAULTS
+                .withConnectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT))
+                .withReadTimeout(Duration.ofSeconds(READ_TIMEOUT));
+
+        return ClientHttpRequestFactories.get(settings);
+    }
+
+    public GithubMember getGithubMember(String accessToken) {
+        return restClient.get()
+                .uri("https://api.github.com/user")
+                .header("X-Github-Api-Version", "2022-11-28")
+                .header(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", accessToken))
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, getGithubMemberErrorHandler())
+                .body(GithubMember.class);
+    }
+
+    private RestClient.ResponseSpec.ErrorHandler getGithubMemberErrorHandler() {
+        return (request, response) -> {
+            throw new IllegalArgumentException("잘못된 엑세스 토큰입니다.");
+        };
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/github/GithubMember.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/github/GithubMember.java
@@ -1,0 +1,33 @@
+package maeilwiki.member.github;
+
+import maeilwiki.member.Member;
+import maeilwiki.member.Provider;
+
+public record GithubMember(
+        Long id,
+        String name,
+        String login,
+        String avatarUrl
+) {
+
+    public Member toMember() {
+        String actualName = generateName();
+        String providerId = generateProviderId(id);
+
+        return new Member(actualName, providerId, Provider.GITHUB, avatarUrl);
+    }
+
+    private String generateName() {
+        if (name == null) {
+            return login;
+        }
+
+        return name;
+    }
+
+    private String generateProviderId(Long id) {
+        String providerIdPrefix = Provider.GITHUB.getProviderIdPrefix();
+
+        return String.format(providerIdPrefix, id);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/github/GithubMemberFactory.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/github/GithubMemberFactory.java
@@ -1,0 +1,17 @@
+package maeilwiki.member.github;
+
+import lombok.RequiredArgsConstructor;
+import maeilwiki.member.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GithubMemberFactory {
+
+    private final GithubClient githubClient;
+
+    public Member create(String accessToken) {
+        GithubMember githubMember = githubClient.getGithubMember(accessToken);
+        return githubMember.toMember();
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/WikiService.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/WikiService.java
@@ -24,6 +24,7 @@ class WikiService {
     public void create(WikiRequest request) {
         String uuid = UUID.randomUUID().toString();
         Member temporalMember = new Member(uuid, uuid, "GITHUB");
+        temporalMember.setRefreshToken("temp");
         memberRepository.save(temporalMember);
         Wiki wiki = request.toWiki(temporalMember); // TODO : 로그인 구현
 

--- a/maeil-wiki/src/main/resources/application-local-wiki.yml
+++ b/maeil-wiki/src/main/resources/application-local-wiki.yml
@@ -2,3 +2,6 @@ token:
   secret-key: YXBwbGljYXRpb24tbG9jYWwtc2VjcmV0
   access-exp-time: 7d
   refresh-exp-time: 365d
+
+client:
+  secret: clientSecret

--- a/maeil-wiki/src/main/resources/application-local-wiki.yml
+++ b/maeil-wiki/src/main/resources/application-local-wiki.yml
@@ -1,0 +1,4 @@
+token:
+  secret-key: YXBwbGljYXRpb24tbG9jYWwtc2VjcmV0
+  access-exp-time: 7d
+  refresh-exp-time: 365d

--- a/maeil-wiki/src/main/resources/application-prod-wiki.yml
+++ b/maeil-wiki/src/main/resources/application-prod-wiki.yml
@@ -2,3 +2,6 @@ token:
   secret-key: ${token.secret-key}
   access-exp-time: ${token.access-exp-time}
   refresh-exp-time: ${token.refresh-exp-time}
+
+client:
+  secret: ${client.secret}

--- a/maeil-wiki/src/main/resources/application-prod-wiki.yml
+++ b/maeil-wiki/src/main/resources/application-prod-wiki.yml
@@ -1,0 +1,4 @@
+token:
+  secret-key: ${token.secret-key}
+  access-exp-time: ${token.access-exp-time}
+  refresh-exp-time: ${token.refresh-exp-time}

--- a/maeil-wiki/src/test/java/maeilwiki/comment/CommentRepositoryTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/comment/CommentRepositoryTest.java
@@ -42,6 +42,7 @@ class CommentRepositoryTest extends IntegrationTestSupport {
 
     private Member createMember() {
         Member member = new Member(UUID.randomUUID().toString(), UUID.randomUUID().toString(), "GITHUB");
+        member.setRefreshToken("refresh");
 
         return memberRepository.save(member);
     }

--- a/maeil-wiki/src/test/java/maeilwiki/comment/CommentServiceTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/comment/CommentServiceTest.java
@@ -74,6 +74,8 @@ class CommentServiceTest extends IntegrationTestSupport {
 
     private Comment createComment() {
         Member member = new Member("name", "providerId", "GITHUB");
+        member.setRefreshToken("refresh");
+
         memberRepository.save(member);
 
         Wiki wiki = new Wiki("question", "backend", false, member);

--- a/maeil-wiki/src/test/java/maeilwiki/member/MemberServiceTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/member/MemberServiceTest.java
@@ -1,0 +1,58 @@
+package maeilwiki.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import maeilwiki.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("클라이언트 시크릿이 다르다면 회원 등록 처리를 할 수 없다.")
+    void validateClientSecret() {
+        MemberRequest memberRequest = new MemberRequest("accessToken", "unknownSecret");
+
+        assertThatThrownBy(() -> memberService.apply(memberRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("올바른 클라이언트 암호를 입력해주세요.");
+    }
+
+    @Test
+    @DisplayName("기회원인 경우, 리프레시를 갱신하고 새로운 토큰을 발급한다. (로그인)")
+    void signIn() throws InterruptedException {
+        MemberRequest request = new MemberRequest("accessToken", "clientSecret");
+        MemberTokenResponse originResponse = memberService.apply(request);
+
+        // 로그인 케이스에서 token 재발급 간격이 테스트 상에서 매우 짧아서 같은 토큰이 반환되기 때문에 Thread.sleep()을 추가했습니다.
+        Thread.sleep(1000);
+        MemberTokenResponse newResponse = memberService.apply(request);
+
+        List<Member> members = memberRepository.findAll();
+        assertAll(
+                () -> assertThat(members).hasSize(1),
+                () -> assertThat(originResponse).isNotEqualTo(newResponse)
+        );
+    }
+
+    @Test
+    @DisplayName("기회원이 아닌 경우, 회원 가입 처리를 한다. (회원가입)")
+    void signUp() {
+        MemberRequest request = new MemberRequest("accessToken", "clientSecret");
+
+        MemberTokenResponse response = memberService.apply(request);
+
+        List<Member> members = memberRepository.findAll();
+        assertThat(members).hasSize(1);
+    }
+}

--- a/maeil-wiki/src/test/java/maeilwiki/member/MemberTokenGeneratorTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/member/MemberTokenGeneratorTest.java
@@ -1,0 +1,38 @@
+package maeilwiki.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Base64;
+import maeilwiki.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberTokenGeneratorTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberTokenGenerator memberTokenGenerator;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("HS254 알고리즘을 사용한다.")
+    void checkAlg() {
+        Member member = new Member("name", "test1234", "GITHUB");
+        String refreshToken = memberTokenGenerator.generateRefreshToken();
+        member.setRefreshToken(refreshToken);
+        memberRepository.save(member);
+        String accessToken = memberTokenGenerator.generateAccessToken(member);
+
+        Base64.Decoder decoder = Base64.getDecoder();
+        String decodedAccessTokenHeader = new String(decoder.decode(accessToken.split("\\.")[0]));
+        String decodedRefreshTokenHeader = new String(decoder.decode(refreshToken.split("\\.")[0]));
+
+        assertAll(
+                () -> assertThat(decodedAccessTokenHeader).contains("HS256"),
+                () -> assertThat(decodedRefreshTokenHeader).contains("HS256")
+        );
+    }
+}

--- a/maeil-wiki/src/test/java/maeilwiki/member/github/GithubClientLearningTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/member/github/GithubClientLearningTest.java
@@ -1,0 +1,24 @@
+package maeilwiki.member.github;
+
+import maeilwiki.support.IntegrationTestSupport;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * 참고: https://docs.github.com/ko/rest/users/users?apiVersion=2022-11-28
+ */
+class GithubClientLearningTest extends IntegrationTestSupport {
+
+    @Autowired
+    private GithubClient githubClient;
+
+    @Test
+    @Disabled
+    @DisplayName("사용자 정보 조회 API 학습 테스트")
+    void learningTest() {
+        String accessToken = "atom"; // GITHUB developer setting에서 테스트 용으로 발급
+        GithubMember githubMember = githubClient.getGithubMember(accessToken);
+    }
+}

--- a/maeil-wiki/src/test/java/maeilwiki/member/github/GithubMemberTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/member/github/GithubMemberTest.java
@@ -1,0 +1,30 @@
+package maeilwiki.member.github;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import maeilwiki.member.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GithubMemberTest {
+
+    @Test
+    @DisplayName("사용자 이름이 존재하지 않으면, 계정 이름으로 대체한다.")
+    void replaceName() {
+        String expected = "atom";
+        GithubMember githubMember = new GithubMember(1234L, null, expected, null);
+        Member member = githubMember.toMember();
+
+        assertThat(member.getName()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("깃헙 사용자의 프로바이더 식별자는 GH 프리픽스로 시작한다.")
+    void prefixWithGh() {
+        String expected = "atom";
+        GithubMember githubMember = new GithubMember(1234L, null, expected, null);
+        Member member = githubMember.toMember();
+
+        assertThat(member.getProviderId()).isEqualTo("GH-1234");
+    }
+}

--- a/maeil-wiki/src/test/java/maeilwiki/support/IntegrationTestSupport.java
+++ b/maeil-wiki/src/test/java/maeilwiki/support/IntegrationTestSupport.java
@@ -1,8 +1,15 @@
 package maeilwiki.support;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import maeilwiki.WikiConfiguration;
+import maeilwiki.member.github.GithubClient;
+import maeilwiki.member.github.GithubMember;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,5 +22,15 @@ public abstract class IntegrationTestSupport {
     @EnableJpaAuditing
     @TestConfiguration
     public static class TestConfig {
+
+        @Bean
+        public GithubClient githubClient() {
+            GithubClient githubClient = mock(GithubClient.class);
+            GithubMember githubMember = new GithubMember(1234L, "atom", "atom", "www.naver.com");
+            when(githubClient.getGithubMember(any()))
+                    .thenReturn(githubMember);
+
+            return githubClient;
+        }
     }
 }

--- a/maeil-wiki/src/test/java/maeilwiki/wiki/WikiServiceTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/wiki/WikiServiceTest.java
@@ -61,6 +61,7 @@ class WikiServiceTest extends IntegrationTestSupport {
 
     private Member createMember() {
         Member member = new Member(UUID.randomUUID().toString(), UUID.randomUUID().toString(), "GITHUB");
+        member.setRefreshToken("refresh");
 
         return memberRepository.save(member);
     }

--- a/maeil-wiki/src/test/resources/application.yml
+++ b/maeil-wiki/src/test/resources/application.yml
@@ -12,3 +12,8 @@ spring:
   sql:
     init:
       mode: never
+
+token:
+  secret-key: YXBwbGljYXRpb24tbG9jYWwtc2VjcmV0
+  access-exp-time: 7d
+  refresh-exp-time: 365d

--- a/maeil-wiki/src/test/resources/application.yml
+++ b/maeil-wiki/src/test/resources/application.yml
@@ -17,3 +17,6 @@ token:
   secret-key: YXBwbGljYXRpb24tbG9jYWwtc2VjcmV0
   access-exp-time: 7d
   refresh-exp-time: 365d
+
+client:
+  secret: clientSecret


### PR DESCRIPTION
- close #178 
- 회원 인증 및 회원 가입 기능을 구현했어요. 
    - 기존재 회원의 요청이라면, 인증으로 판단하여 토큰을 갱신합니다.
    - 신규 회원의 요청이라면, 회원가입 및 인증으로 판단하여 회원을 등록하고 토큰을 설정해요.
    - 토큰은 jjwt 라이브러리를 사용했어요. java-jwt 랑 비교해서 버전이 낮다는 점이 마음에 걸렸지만, 근래에도 활발히 유지보수가 진행된다는 점이 결정 근거였어요.  
     - jwt에 사용한 알고리즘은 jjwt 디펄트 알고리즘은 HS256을 사용했습니다.
- 해당 요청에 clientSecret이 필요한 이유는 서버에서 accessToken만 받는 경우, 발생할 수 있는 비정상 케이스를 예방하기 위함이에요.
    - 외부 oauth 로그인으로 accessToken을 얻거나, developer setting으로 accessToken을 생성한다.
    - 직접 서버로 accessToken만 포함한 요청을 보낸다. 
    - 회원 가입이 성공한다.