### PR TITLE
토큰 수신 및 응답을 쿠키로 전환한다.

### DIFF
--- a/maeil-mail/src/main/java/maeilmail/support/WebMvcConfig.java
+++ b/maeil-mail/src/main/java/maeilmail/support/WebMvcConfig.java
@@ -38,7 +38,9 @@ class WebMvcConfig implements WebMvcConfigurer {
                         "https://maeil-mail.vercel.app",
                         "https://maeil-mail-fe.vercel.app",
                         "https://www.maeil-mail.kr",
-                        "https://maeil-mail.kr"
-                );
+                        "https://maeil-mail.kr",
+                        "https://wiki.maeil-mail.kr"
+                )
+                .allowCredentials(true);
     }
 }

--- a/maeil-mail/src/test/java/maeilmail/support/ApiTestSupport.java
+++ b/maeil-mail/src/test/java/maeilmail/support/ApiTestSupport.java
@@ -4,6 +4,7 @@ import maeilmail.question.QuestionApi;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.subscribe.api.SubscribeQuestionApi;
 import maeilmail.subscribe.query.SubscribeQuestionQueryService;
+import maeilwiki.member.api.MemberIdentityCookieHelper;
 import maeilwiki.member.infra.MemberTokenAuthorizer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,4 +25,7 @@ public abstract class ApiTestSupport {
 
     @MockBean
     protected MemberTokenAuthorizer memberTokenAuthorizer;
+
+    @MockBean
+    protected MemberIdentityCookieHelper memberIdentityCookieHelper;
 }

--- a/maeil-wiki/src/main/java/maeilwiki/member/api/MemberIdentityCookieHelper.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/api/MemberIdentityCookieHelper.java
@@ -1,0 +1,61 @@
+package maeilwiki.member.api;
+
+import static maeilwiki.member.api.MemberIdentityCookieType.ACCESS_TOKEN;
+import static maeilwiki.member.api.MemberIdentityCookieType.REFRESH_TOKEN;
+
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import maeilwiki.member.infra.MemberTokenProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class MemberIdentityCookieHelper {
+
+    private final MemberTokenProperties properties;
+
+    @Value("${domain}")
+    private String serverDomain;
+
+    public String generateAccessTokenCookie(String value) {
+        return ResponseCookie.from(ACCESS_TOKEN.getName(), value)
+                .domain(serverDomain)
+                .path("/")
+                .maxAge(properties.accessExpTime())
+                .sameSite("none")
+                .httpOnly(true)
+                .secure(true)
+                .build()
+                .toString();
+    }
+
+    public String generateRefreshTokenCookie(String value, String path) {
+        return ResponseCookie.from(REFRESH_TOKEN.getName(), value)
+                .domain(serverDomain)
+                .path(path)
+                .maxAge(properties.refreshExpTime())
+                .sameSite("none")
+                .httpOnly(true)
+                .secure(true)
+                .build()
+                .toString();
+    }
+
+    public String getCookieByName(Cookie[] cookies, MemberIdentityCookieType cookieType) {
+        if (cookies == null || cookies.length == 0) {
+            return null;
+        }
+
+        String target = null;
+        for (Cookie cookie : cookies) {
+            String name = cookie.getName();
+            if (name.equals(cookieType.getName())) {
+                target = cookie.getValue();
+            }
+        }
+
+        return target;
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/member/api/MemberIdentityCookieHelper.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/api/MemberIdentityCookieHelper.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-class MemberIdentityCookieHelper {
+public class MemberIdentityCookieHelper {
 
     private final MemberTokenProperties properties;
 

--- a/maeil-wiki/src/main/java/maeilwiki/member/api/MemberIdentityCookieType.java
+++ b/maeil-wiki/src/main/java/maeilwiki/member/api/MemberIdentityCookieType.java
@@ -1,0 +1,15 @@
+package maeilwiki.member.api;
+
+import lombok.Getter;
+
+@Getter
+enum MemberIdentityCookieType {
+
+    ACCESS_TOKEN("accessToken"), REFRESH_TOKEN("refreshToken");
+
+    private final String name;
+
+    MemberIdentityCookieType(String name) {
+        this.name = name;
+    }
+}

--- a/maeil-wiki/src/main/resources/application-local-wiki.yml
+++ b/maeil-wiki/src/main/resources/application-local-wiki.yml
@@ -2,3 +2,5 @@ token:
   secret-key: YXBwbGljYXRpb24tbG9jYWwtc2VjcmV0
   access-exp-time: 7d
   refresh-exp-time: 365d
+
+domain: localhost

--- a/maeil-wiki/src/main/resources/application-prod-wiki.yml
+++ b/maeil-wiki/src/main/resources/application-prod-wiki.yml
@@ -2,3 +2,5 @@ token:
   secret-key: ${token.secret-key}
   access-exp-time: ${token.access-exp-time}
   refresh-exp-time: ${token.refresh-exp-time}
+
+domain: maeil-mail.site

--- a/maeil-wiki/src/test/java/maeilwiki/member/api/MemberIdentityCookieHelperTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/member/api/MemberIdentityCookieHelperTest.java
@@ -1,0 +1,59 @@
+package maeilwiki.member.api;
+
+import static maeilwiki.member.api.MemberIdentityCookieType.ACCESS_TOKEN;
+import static maeilwiki.member.api.MemberIdentityCookieType.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import jakarta.servlet.http.Cookie;
+import maeilwiki.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberIdentityCookieHelperTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberIdentityCookieHelper helper;
+
+    @Test
+    @DisplayName("주어진 쿠키 목록에서 원하는 쿠키를 조회할 수 있다.")
+    void getCookieById() {
+        String expectedValue = "1234";
+        Cookie accessCookie = new Cookie(ACCESS_TOKEN.getName(), expectedValue);
+        Cookie refreshCookie = new Cookie(REFRESH_TOKEN.getName(), "1234");
+
+        Cookie[] cookies = {accessCookie, refreshCookie};
+
+        String result = helper.getCookieByName(cookies, ACCESS_TOKEN);
+
+        assertThat(result).isEqualTo(expectedValue);
+    }
+
+    @Test
+    @DisplayName("쿠키를 찾을 수 없는 경우, null을 반환한다.")
+    void cookieNotFound() {
+        Cookie accessCookie = new Cookie(ACCESS_TOKEN.getName(), "1234");
+        Cookie[] cookies = {accessCookie};
+
+        String result = helper.getCookieByName(cookies, REFRESH_TOKEN);
+
+        assertThat(result).isNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateInvalidCookies")
+    @DisplayName("쿠키 배열이 비정상 케이스인 경우, null을 반환한다.")
+    void invalidCookies(Cookie[] cookies) {
+        String result = helper.getCookieByName(cookies, ACCESS_TOKEN);
+
+        assertThat(result).isNull();
+    }
+
+    public static Stream<Arguments> generateInvalidCookies() {
+        return Stream.of(Arguments.of((Object) new Cookie[]{}), Arguments.of((Object) null));
+    }
+}

--- a/maeil-wiki/src/test/java/maeilwiki/member/api/MemberIdentityCookieHelperTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/member/api/MemberIdentityCookieHelperTest.java
@@ -22,9 +22,9 @@ class MemberIdentityCookieHelperTest extends IntegrationTestSupport {
     @Test
     @DisplayName("주어진 쿠키 목록에서 원하는 쿠키를 조회할 수 있다.")
     void getCookieById() {
-        String expectedValue = "1234";
+        String expectedValue = "accessToken";
         Cookie accessCookie = new Cookie(ACCESS_TOKEN.getName(), expectedValue);
-        Cookie refreshCookie = new Cookie(REFRESH_TOKEN.getName(), "1234");
+        Cookie refreshCookie = new Cookie(REFRESH_TOKEN.getName(), "refreshToken");
 
         Cookie[] cookies = {accessCookie, refreshCookie};
 

--- a/maeil-wiki/src/test/resources/application.yml
+++ b/maeil-wiki/src/test/resources/application.yml
@@ -18,8 +18,7 @@ token:
   access-exp-time: 7d
   refresh-exp-time: 365d
 
-client:
-  secret: clientSecret
+domain: localhost
 
 logging:
   level:


### PR DESCRIPTION
- close #187 
- 기존 json 형식으로 반환하던 토큰을 쿠키로 변경했어요. 기존 플로우에서 nextjs 경유하는 부분이 비효율적이라고 판단하여 변경했습니다.