### PR TITLE
위키 상세 조회와 댓글 조회를 분리한다

### DIFF
--- a/maeil-mail/src/main/java/maeilmail/admin/AdminApi.java
+++ b/maeil-mail/src/main/java/maeilmail/admin/AdminApi.java
@@ -1,6 +1,5 @@
 package maeilmail.admin;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
@@ -9,13 +8,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -29,9 +24,10 @@ public class AdminApi {
     @GetMapping("/admin/question")
     public ResponseEntity<PaginationResponse<QuestionSummary>> getQuestions(
             @RequestParam(defaultValue = "all") String category,
+            @RequestParam(defaultValue = "") String searchParam,
             @PageableDefault Pageable pageable
     ) {
-        PaginationResponse<QuestionSummary> response = questionQueryService.pageByCategory(category, pageable);
+        PaginationResponse<QuestionSummary> response = questionQueryService.pageByCategory(category, searchParam, pageable);
 
         return ResponseEntity.ok(response);
     }

--- a/maeil-mail/src/main/java/maeilmail/question/QuestionQueryService.java
+++ b/maeil-mail/src/main/java/maeilmail/question/QuestionQueryService.java
@@ -26,13 +26,13 @@ public class QuestionQueryService {
 
     private final JPAQueryFactory queryFactory;
 
-    public PaginationResponse<QuestionSummary> pageByCategory(String category, Pageable pageable) {
+    public PaginationResponse<QuestionSummary> pageByCategory(String category, String searchParam, Pageable pageable) {
         JPAQuery<Long> countQuery = queryFactory.select(question.count())
                 .from(question)
                 .where(eqCategory(category));
         JPAQuery<QuestionSummary> resultQuery = queryFactory.select(projectionQuestionSummary())
                 .from(question)
-                .where(eqCategory(category))
+                .where(eqCategory(category), eqSearchParam(searchParam))
                 .offset(pageable.getOffset())
                 .orderBy(question.id.desc())
                 .limit(pageable.getPageSize());
@@ -56,6 +56,14 @@ public class QuestionQueryService {
         }
 
         return question.category.eq(QuestionCategory.from(category));
+    }
+
+    private BooleanExpression eqSearchParam(String searchParam) {
+        if (searchParam == null || searchParam.isEmpty()) {
+            return null;
+        }
+        return question.title.likeIgnoreCase(searchParam)
+                .or(question.content.likeIgnoreCase(searchParam));
     }
 
     public QuestionSummary queryOneById(Long id) {

--- a/maeil-mail/src/main/java/maeilmail/question/QuestionQueryService.java
+++ b/maeil-mail/src/main/java/maeilmail/question/QuestionQueryService.java
@@ -1,9 +1,5 @@
 package maeilmail.question;
 
-import static maeilmail.question.QQuestion.question;
-
-import java.util.List;
-import java.util.NoSuchElementException;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -16,6 +12,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static maeilmail.question.QQuestion.question;
 
 @Slf4j
 @Service
@@ -72,7 +73,9 @@ public class QuestionQueryService {
                 question.title,
                 question.content,
                 question.customizedTitle,
-                question.category.stringValue().lower()
+                question.category.stringValue().lower(),
+                question.createdAt,
+                question.updatedAt
         );
     }
 

--- a/maeil-mail/src/main/java/maeilmail/question/QuestionSummary.java
+++ b/maeil-mail/src/main/java/maeilmail/question/QuestionSummary.java
@@ -2,7 +2,17 @@ package maeilmail.question;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-public record QuestionSummary(Long id, String title, String content, String customizedTitle, String category) {
+import java.time.LocalDateTime;
+
+public record QuestionSummary(
+        Long id,
+        String title,
+        String content,
+        String customizedTitle,
+        String category,
+        LocalDateTime createdDateTime,
+        LocalDateTime modifiedDateTime
+) {
 
     @QueryProjection
     public QuestionSummary {

--- a/maeil-mail/src/test/java/maeilmail/admin/AdminApiTest.java
+++ b/maeil-mail/src/test/java/maeilmail/admin/AdminApiTest.java
@@ -1,16 +1,5 @@
 package maeilmail.admin;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
 import maeilmail.question.QuestionSummary;
 import maeilmail.support.ApiTestSupport;
 import maeilsupport.PaginationResponse;
@@ -19,6 +8,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class AdminApiTest extends ApiTestSupport {
 
@@ -29,9 +28,10 @@ class AdminApiTest extends ApiTestSupport {
     @DisplayName("페이징 처리된 질문지를 조회할때 기본 값은 page = 0, pageSize = 10, category = 'all' 이다.")
     void getQuestionsDefault() throws Exception {
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        ArgumentCaptor<String> searchParamCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> categoryCaptor = ArgumentCaptor.forClass(String.class);
         PaginationResponse<QuestionSummary> response = new PaginationResponse<>(true, 0L, Collections.emptyList());
-        when(questionQueryService.pageByCategory(any(), any()))
+        when(questionQueryService.pageByCategory(any(), any(), any()))
                 .thenReturn(response);
 
         mockMvc.perform(get("/admin/question").header("Authorization", "Basic " + secret))
@@ -39,12 +39,14 @@ class AdminApiTest extends ApiTestSupport {
                 .andExpect(status().isOk());
 
         verify(questionQueryService, times(1))
-                .pageByCategory(categoryCaptor.capture(), pageableCaptor.capture());
+                .pageByCategory(categoryCaptor.capture(), searchParamCaptor.capture(), pageableCaptor.capture());
         Pageable actualPageable = pageableCaptor.getValue();
         String actualCategory = categoryCaptor.getValue();
+        String actualSearchParam = searchParamCaptor.getValue();
 
         assertAll(
                 () -> assertThat(actualCategory).isEqualTo("all"),
+                () -> assertThat(actualSearchParam).isEqualTo(""),
                 () -> assertThat(actualPageable.getPageSize()).isEqualTo(10),
                 () -> assertThat(actualPageable.getPageNumber()).isEqualTo(0)
         );

--- a/maeil-mail/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
+++ b/maeil-mail/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
@@ -1,19 +1,20 @@
 package maeilmail.question;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.NoSuchElementException;
 import maeilmail.support.IntegrationTestSupport;
 import maeilsupport.PaginationResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class QuestionQueryServiceTest extends IntegrationTestSupport {
 
@@ -72,7 +73,7 @@ class QuestionQueryServiceTest extends IntegrationTestSupport {
                 .subList(0, pageSize);
 
         PaginationResponse<QuestionSummary> response
-                = questionQueryService.pageByCategory("backend", PageRequest.of(0, pageSize));
+                = questionQueryService.pageByCategory("backend", null, PageRequest.of(0, pageSize));
 
         assertAll(
                 () -> assertThat(response.isLastPage()).isFalse(),

--- a/maeil-wiki/src/main/java/maeilwiki/comment/application/CommentResponse.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/application/CommentResponse.java
@@ -1,8 +1,9 @@
 package maeilwiki.comment.application;
 
-import java.time.LocalDateTime;
 import maeilwiki.comment.dto.CommentSummary;
 import maeilwiki.member.dto.MemberThumbnail;
+
+import java.time.LocalDateTime;
 
 public record CommentResponse(
         Long id,
@@ -13,12 +14,12 @@ public record CommentResponse(
         MemberThumbnail owner
 ) {
 
-    public static CommentResponse of(CommentSummary commentSummary, boolean isLiked) {
+    public static CommentResponse of(CommentSummary commentSummary) {
         return new CommentResponse(
                 commentSummary.id(),
                 commentSummary.answer(),
                 commentSummary.createdAt(),
-                isLiked,
+                commentSummary.isLiked(),
                 commentSummary.likeCount(),
                 commentSummary.owner()
         );

--- a/maeil-wiki/src/main/java/maeilwiki/comment/application/CommentResponses.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/application/CommentResponses.java
@@ -1,0 +1,19 @@
+package maeilwiki.comment.application;
+
+import maeilwiki.comment.dto.CommentSummary;
+
+import java.util.List;
+
+public record CommentResponses(
+        List<CommentResponse> commentResponses,
+        Long totalCount
+) {
+
+    public static CommentResponses of(List<CommentSummary> commentSummaries, Long totalCount) {
+        List<CommentResponse> commentResponses = commentSummaries.stream()
+                .map(CommentResponse::of)
+                .toList();
+
+        return new CommentResponses(commentResponses, totalCount);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/comment/application/CommentService.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/application/CommentService.java
@@ -1,16 +1,19 @@
 package maeilwiki.comment.application;
 
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import maeilwiki.comment.domain.Comment;
 import maeilwiki.comment.domain.CommentLike;
 import maeilwiki.comment.domain.CommentLikeRepository;
 import maeilwiki.comment.domain.CommentRepository;
+import maeilwiki.comment.dto.CommentSummary;
 import maeilwiki.member.application.MemberIdentity;
 import maeilwiki.member.application.MemberService;
 import maeilwiki.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -62,5 +65,13 @@ public class CommentService {
     private void like(Member member, Comment comment) {
         CommentLike commentLike = new CommentLike(member, comment);
         commentLikeRepository.save(commentLike);
+    }
+
+    @Transactional(readOnly = true)
+    public CommentResponses list(MemberIdentity identity, Long wikiId, Long cursorId, Long size) {
+        List<CommentSummary> commentSummaries = commentRepository.queryByWikiIdAndIdGreaterThan(wikiId, identity.id(), cursorId, size);
+        Long totalCount = commentRepository.countAllByWikiId(wikiId);
+
+        return CommentResponses.of(commentSummaries, totalCount);
     }
 }

--- a/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepository.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
     boolean existsByWikiIdAndDeletedAtIsNull(Long wikiId);
+
+    Long countAllByWikiId(Long wikiId);
 }

--- a/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepositoryCustom.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepositoryCustom.java
@@ -1,9 +1,12 @@
 package maeilwiki.comment.domain;
 
-import java.util.List;
 import maeilwiki.comment.dto.CommentSummary;
+
+import java.util.List;
 
 public interface CommentRepositoryCustom {
 
-    List<CommentSummary> queryAllByWikiId(Long wikiId);
+    List<CommentSummary> queryByWikiIdAndIdGreaterThan(Long wikiId, Long memberId, Long cursorId, Long size);
+
+    Long countAllByWikiId(Long wikiId);
 }

--- a/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepositoryImpl.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepositoryImpl.java
@@ -1,18 +1,19 @@
 package maeilwiki.comment.domain;
 
-import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.set;
-import static maeilwiki.comment.domain.QComment.comment;
-import static maeilwiki.comment.domain.QCommentLike.commentLike;
-import static maeilwiki.member.domain.QMember.member;
-
-import java.util.List;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import maeilwiki.comment.dto.CommentSummary;
 import maeilwiki.comment.dto.QCommentSummary;
 import maeilwiki.member.dto.QMemberThumbnail;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static maeilwiki.comment.domain.QComment.comment;
+import static maeilwiki.comment.domain.QCommentLike.commentLike;
+import static maeilwiki.member.domain.QMember.member;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,25 +22,46 @@ class CommentRepositoryImpl implements CommentRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<CommentSummary> queryAllByWikiId(Long wikiId) {
-        return queryFactory.from(comment)
+    public List<CommentSummary> queryByWikiIdAndIdGreaterThan(Long wikiId, Long memberId, Long cursorId, Long size) {
+        return queryFactory.select(projectionCommentSummary(memberId))
+                .from(comment)
                 .join(member).on(comment.member.eq(member))
-                .leftJoin(commentLike).on(comment.eq(commentLike.comment))
-                .where(comment.wikiId.eq(wikiId)
-                        .and(comment.deletedAt.isNull()))
+                .where(comment.wikiId.eq(wikiId),
+                        comment.deletedAt.isNull(),
+                        cursorId != null ? comment.id.gt(cursorId) : null)
                 .orderBy(comment.id.asc())
-                .transform(groupBy(comment.id)
-                        .list(projectionCommentSummary()));
+                .limit(size)
+                .fetch();
     }
 
-    private QCommentSummary projectionCommentSummary() {
+    private QCommentSummary projectionCommentSummary(Long memberId) {
         return new QCommentSummary(
                 comment.id,
                 comment.answer,
                 comment.isAnonymous,
+                memberId != null
+                        ? JPAExpressions.selectOne()
+                        .from(commentLike)
+                        .where(
+                                commentLike.comment.eq(comment),
+                                commentLike.member.id.eq(memberId)
+                        )
+                        .exists()
+                        : Expressions.constant(false),
+                JPAExpressions.select(commentLike.id.count())
+                        .from(commentLike)
+                        .where(commentLike.comment.eq(comment)),
                 comment.createdAt,
-                set(commentLike.member.id),
                 new QMemberThumbnail(member.id, member.name, member.profileImageUrl, member.githubUrl)
         );
     }
+
+    @Override
+    public Long countAllByWikiId(Long wikiId) {
+        return queryFactory.select(comment.id.count())
+                .from(comment)
+                .where(comment.wikiId.eq(wikiId))
+                .fetchOne();
+    }
 }
+

--- a/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepositoryImpl.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/domain/CommentRepositoryImpl.java
@@ -1,5 +1,6 @@
 package maeilwiki.comment.domain;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -28,7 +29,7 @@ class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .join(member).on(comment.member.eq(member))
                 .where(comment.wikiId.eq(wikiId),
                         comment.deletedAt.isNull(),
-                        cursorId != null ? comment.id.gt(cursorId) : null)
+                        idGreaterThan(cursorId))
                 .orderBy(comment.id.asc())
                 .limit(size)
                 .fetch();
@@ -56,6 +57,13 @@ class CommentRepositoryImpl implements CommentRepositoryCustom {
         );
     }
 
+    private BooleanExpression idGreaterThan(Long cursorId) {
+        if (cursorId == null) {
+            return null;
+        }
+        return comment.id.gt(cursorId);
+    }
+
     @Override
     public Long countAllByWikiId(Long wikiId) {
         return queryFactory.select(comment.id.count())
@@ -64,4 +72,3 @@ class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .fetchOne();
     }
 }
-

--- a/maeil-wiki/src/main/java/maeilwiki/comment/dto/CommentSummary.java
+++ b/maeil-wiki/src/main/java/maeilwiki/comment/dto/CommentSummary.java
@@ -1,16 +1,17 @@
 package maeilwiki.comment.dto;
 
-import java.time.LocalDateTime;
-import java.util.Set;
 import com.querydsl.core.annotations.QueryProjection;
 import maeilwiki.member.dto.MemberThumbnail;
+
+import java.time.LocalDateTime;
 
 public record CommentSummary(
         Long id,
         String answer,
         boolean isAnonymous,
+        boolean isLiked,
+        Long likeCount,
         LocalDateTime createdAt,
-        Set<Long> likeMemberIds,
         MemberThumbnail owner
 ) {
 
@@ -21,14 +22,6 @@ public record CommentSummary(
     public CommentSummary toAnonymousOwner() {
         MemberThumbnail anonymousOwner = new MemberThumbnail(owner.id(), null, null, null);
 
-        return new CommentSummary(id, answer, isAnonymous, createdAt, likeMemberIds, anonymousOwner);
-    }
-
-    public boolean isLikedBy(Long memberId) {
-        return likeMemberIds.contains(memberId);
-    }
-
-    public long likeCount() {
-        return likeMemberIds.size();
+        return new CommentSummary(id, answer, isAnonymous, isLiked, likeCount, createdAt, anonymousOwner);
     }
 }

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/application/WikiResponse.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/application/WikiResponse.java
@@ -1,13 +1,12 @@
 package maeilwiki.wiki.application;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include;
-
-import java.time.LocalDateTime;
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import maeilwiki.comment.application.CommentResponse;
 import maeilwiki.member.dto.MemberThumbnail;
 import maeilwiki.wiki.dto.WikiSummary;
+
+import java.time.LocalDateTime;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 public record WikiResponse(
         Long id,
@@ -16,11 +15,10 @@ public record WikiResponse(
         String category,
         MemberThumbnail owner,
         LocalDateTime createdAt,
-        @JsonInclude(Include.NON_NULL) List<CommentResponse> comments,
-        @JsonInclude(Include.NON_NULL) Long commentCount
+        Long commentCount
 ) {
 
-    public static WikiResponse withComments(WikiSummary wikiSummary, List<CommentResponse> commentResponses) {
+    public static WikiResponse of(WikiSummary wikiSummary, Long commentCount) {
         return new WikiResponse(
                 wikiSummary.id(),
                 wikiSummary.question(),
@@ -28,20 +26,6 @@ public record WikiResponse(
                 wikiSummary.category(),
                 wikiSummary.owner(),
                 wikiSummary.createdAt(),
-                commentResponses,
-                null
-        );
-    }
-
-    public static WikiResponse withCommentCount(WikiSummary wikiSummary, Long commentCount) {
-        return new WikiResponse(
-                wikiSummary.id(),
-                wikiSummary.question(),
-                wikiSummary.questionDetail(),
-                wikiSummary.category(),
-                wikiSummary.owner(),
-                wikiSummary.createdAt(),
-                null,
                 commentCount
         );
     }

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/domain/WikiRepositoryImpl.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/domain/WikiRepositoryImpl.java
@@ -1,10 +1,5 @@
 package maeilwiki.wiki.domain;
 
-import static maeilwiki.comment.domain.QComment.comment;
-import static maeilwiki.member.domain.QMember.member;
-import static maeilwiki.wiki.domain.QWiki.wiki;
-
-import java.util.Optional;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -18,6 +13,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static maeilwiki.comment.domain.QComment.comment;
+import static maeilwiki.member.domain.QMember.member;
+import static maeilwiki.wiki.domain.QWiki.wiki;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -77,6 +78,7 @@ class WikiRepositoryImpl implements WikiRepositoryCustom {
                 wiki.questionDetail,
                 wiki.category.stringValue().lower(),
                 wiki.isAnonymous,
+
                 wiki.createdAt,
                 projectionMemberThumbnail()
         );

--- a/maeil-wiki/src/test/java/maeilwiki/comment/domain/CommentRepositoryTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/comment/domain/CommentRepositoryTest.java
@@ -1,11 +1,5 @@
 package maeilwiki.comment.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.util.List;
-import java.util.UUID;
 import maeilwiki.comment.dto.CommentSummary;
 import maeilwiki.member.domain.Member;
 import maeilwiki.member.domain.MemberRepository;
@@ -16,6 +10,13 @@ import maeilwiki.wiki.domain.WikiRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class CommentRepositoryTest extends IntegrationTestSupport {
 
@@ -64,7 +65,7 @@ class CommentRepositoryTest extends IntegrationTestSupport {
         createCommentLike(prin, wiki2comment1);
 
         // when
-        List<CommentSummary> commentSummaries = commentRepository.queryAllByWikiId(wiki1.getId());
+        List<CommentSummary> commentSummaries = commentRepository.queryByWikiIdAndIdGreaterThan(wiki1.getId(), prin.getId(), 0L, 10L);
 
         // then
         assertSoftly(softAssertions -> {
@@ -75,7 +76,7 @@ class CommentRepositoryTest extends IntegrationTestSupport {
             softAssertions.assertThat(comment1.answer()).isEqualTo(wiki1comment1.getAnswer());
             softAssertions.assertThat(comment1.isAnonymous()).isEqualTo(wiki1comment1.isAnonymous());
             softAssertions.assertThat(comment1.likeCount()).isEqualTo(2);
-            softAssertions.assertThat(comment1.likeMemberIds()).contains(prin.getId(), leesang.getId());
+            softAssertions.assertThat(comment1.isLiked()).isTrue();
             MemberThumbnail comment1Owner = comment1.owner();
             softAssertions.assertThat(comment1Owner.id()).isEqualTo(atom.getId());
             softAssertions.assertThat(comment1Owner.name()).isEqualTo(atom.getName());
@@ -87,6 +88,7 @@ class CommentRepositoryTest extends IntegrationTestSupport {
             softAssertions.assertThat(comment2.answer()).isEqualTo(wiki1comment2.getAnswer());
             softAssertions.assertThat(comment2.isAnonymous()).isEqualTo(wiki1comment2.isAnonymous());
             softAssertions.assertThat(comment2.likeCount()).isEqualTo(0);
+            softAssertions.assertThat(comment2.isLiked()).isFalse();
             MemberThumbnail comment2Owner = comment2.owner();
             softAssertions.assertThat(comment2Owner.id()).isEqualTo(atom.getId());
             softAssertions.assertThat(comment2Owner.name()).isEqualTo(atom.getName());
@@ -103,7 +105,7 @@ class CommentRepositoryTest extends IntegrationTestSupport {
         Wiki wiki = createWiki(atom);
 
         // when
-        List<CommentSummary> commentSummary = commentRepository.queryAllByWikiId(wiki.getId());
+        List<CommentSummary> commentSummary = commentRepository.queryByWikiIdAndIdGreaterThan(wiki.getId(), null, 0L, 10L);
 
         // then
         assertThat(commentSummary).isEmpty();

--- a/maeil-wiki/src/test/java/maeilwiki/wiki/application/WikiServiceTest.java
+++ b/maeil-wiki/src/test/java/maeilwiki/wiki/application/WikiServiceTest.java
@@ -1,14 +1,7 @@
 package maeilwiki.wiki.application;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.UUID;
 import maeilsupport.PaginationResponse;
 import maeilwiki.comment.application.CommentRequest;
-import maeilwiki.comment.application.CommentResponse;
 import maeilwiki.comment.domain.Comment;
 import maeilwiki.comment.domain.CommentLike;
 import maeilwiki.comment.domain.CommentLikeRepository;
@@ -24,6 +17,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class WikiServiceTest extends IntegrationTestSupport {
 
@@ -126,25 +125,25 @@ class WikiServiceTest extends IntegrationTestSupport {
             softAssertions.assertThat(wikiOwner.name()).isEqualTo(wiki1.getMember().getName());
             softAssertions.assertThat(wikiOwner.profileImage()).isEqualTo(wiki1.getMember().getProfileImageUrl());
             softAssertions.assertThat(wikiOwner.github()).isEqualTo(wiki1.getMember().getGithubUrl());
-            softAssertions.assertThat(wikiResponse.comments()).hasSize(3);
-            CommentResponse commentResponse1 = wikiResponse.comments().get(0);
-            softAssertions.assertThat(commentResponse1.id()).isEqualTo(wiki1Comment1.getId());
-            softAssertions.assertThat(commentResponse1.answer()).isEqualTo(wiki1Comment1.getAnswer());
-            softAssertions.assertThat(commentResponse1.isLiked()).isTrue();
-            softAssertions.assertThat(commentResponse1.likeCount()).isEqualTo(2);
-            softAssertions.assertThat(commentResponse1.owner().id()).isEqualTo(atom.getId());
-            CommentResponse commentResponse2 = wikiResponse.comments().get(1);
-            softAssertions.assertThat(commentResponse2.id()).isEqualTo(wiki1Comment2.getId());
-            softAssertions.assertThat(commentResponse2.answer()).isEqualTo(wiki1Comment2.getAnswer());
-            softAssertions.assertThat(commentResponse2.isLiked()).isFalse();
-            softAssertions.assertThat(commentResponse2.likeCount()).isEqualTo(1);
-            softAssertions.assertThat(commentResponse2.owner().id()).isEqualTo(prin.getId());
-            CommentResponse commentResponse3 = wikiResponse.comments().get(2);
-            softAssertions.assertThat(commentResponse3.id()).isEqualTo(wiki1Comment3.getId());
-            softAssertions.assertThat(commentResponse3.answer()).isEqualTo(wiki1Comment3.getAnswer());
-            softAssertions.assertThat(commentResponse3.isLiked()).isFalse();
-            softAssertions.assertThat(commentResponse3.likeCount()).isEqualTo(0);
-            softAssertions.assertThat(commentResponse3.owner().id()).isEqualTo(leesang.getId());
+            softAssertions.assertThat(wikiResponse.commentCount()).isEqualTo(3);
+//            CommentResponse commentResponse1 = wikiResponse.comments().get(0);
+//            softAssertions.assertThat(commentResponse1.id()).isEqualTo(wiki1Comment1.getId());
+//            softAssertions.assertThat(commentResponse1.answer()).isEqualTo(wiki1Comment1.getAnswer());
+//            softAssertions.assertThat(commentResponse1.isLiked()).isTrue();
+//            softAssertions.assertThat(commentResponse1.likeCount()).isEqualTo(2);
+//            softAssertions.assertThat(commentResponse1.owner().id()).isEqualTo(atom.getId());
+//            CommentResponse commentResponse2 = wikiResponse.comments().get(1);
+//            softAssertions.assertThat(commentResponse2.id()).isEqualTo(wiki1Comment2.getId());
+//            softAssertions.assertThat(commentResponse2.answer()).isEqualTo(wiki1Comment2.getAnswer());
+//            softAssertions.assertThat(commentResponse2.isLiked()).isFalse();
+//            softAssertions.assertThat(commentResponse2.likeCount()).isEqualTo(1);
+//            softAssertions.assertThat(commentResponse2.owner().id()).isEqualTo(prin.getId());
+//            CommentResponse commentResponse3 = wikiResponse.comments().get(2);
+//            softAssertions.assertThat(commentResponse3.id()).isEqualTo(wiki1Comment3.getId());
+//            softAssertions.assertThat(commentResponse3.answer()).isEqualTo(wiki1Comment3.getAnswer());
+//            softAssertions.assertThat(commentResponse3.isLiked()).isFalse();
+//            softAssertions.assertThat(commentResponse3.likeCount()).isEqualTo(0);
+//            softAssertions.assertThat(commentResponse3.owner().id()).isEqualTo(leesang.getId());
         });
     }
 
@@ -167,9 +166,10 @@ class WikiServiceTest extends IntegrationTestSupport {
 
         // then
         assertSoftly(softAssertions -> {
-            List<CommentResponse> comments = wikiResponse.comments();
-            softAssertions.assertThat(comments.get(0).isLiked()).isFalse();
-            softAssertions.assertThat(comments.get(1).isLiked()).isFalse();
+            softAssertions.assertThat(wikiResponse.commentCount()).isEqualTo(2);
+//            List<CommentResponse> comments = wikiResponse.comments();
+//            softAssertions.assertThat(comments.get(0).isLiked()).isFalse();
+//            softAssertions.assertThat(comments.get(1).isLiked()).isFalse();
         });
     }
 
@@ -233,13 +233,13 @@ class WikiServiceTest extends IntegrationTestSupport {
         WikiResponse wikiResponse = wikiService.getWikiById(identity, wiki.getId());
 
         // then
-        assertSoftly(softAssertions -> {
-            MemberThumbnail owner = wikiResponse.comments().get(0).owner();
-            softAssertions.assertThat(owner.id()).isEqualTo(atom.getId());
-            softAssertions.assertThat(owner.name()).isEqualTo(null);
-            softAssertions.assertThat(owner.github()).isEqualTo(null);
-            softAssertions.assertThat(owner.profileImage()).isEqualTo(null);
-        });
+//        assertSoftly(softAssertions -> {
+//            MemberThumbnail owner = wikiResponse.comments().get(0).owner();
+//            softAssertions.assertThat(owner.id()).isEqualTo(atom.getId());
+//            softAssertions.assertThat(owner.name()).isEqualTo(null);
+//            softAssertions.assertThat(owner.github()).isEqualTo(null);
+//            softAssertions.assertThat(owner.profileImage()).isEqualTo(null);
+//        });
     }
 
     @Test
@@ -256,13 +256,13 @@ class WikiServiceTest extends IntegrationTestSupport {
         WikiResponse wikiResponse = wikiService.getWikiById(identity, wiki.getId());
 
         // then
-        assertSoftly(softAssertions -> {
-            MemberThumbnail owner = wikiResponse.comments().get(0).owner();
-            softAssertions.assertThat(owner.id()).isEqualTo(atom.getId());
-            softAssertions.assertThat(owner.name()).isEqualTo(atom.getName());
-            softAssertions.assertThat(owner.github()).isEqualTo(atom.getGithubUrl());
-            softAssertions.assertThat(owner.profileImage()).isEqualTo(atom.getProfileImageUrl());
-        });
+//        assertSoftly(softAssertions -> {
+//            MemberThumbnail owner = wikiResponse.comments().get(0).owner();
+//            softAssertions.assertThat(owner.id()).isEqualTo(atom.getId());
+//            softAssertions.assertThat(owner.name()).isEqualTo(atom.getName());
+//            softAssertions.assertThat(owner.github()).isEqualTo(atom.getGithubUrl());
+//            softAssertions.assertThat(owner.profileImage()).isEqualTo(atom.getProfileImageUrl());
+//        });
     }
 
     @Test


### PR DESCRIPTION
- close #228 

분리해봤습니다.
이 pr을 메인에 반영하지 않더라도, 의견을 나누고자 올려봅니다.
아톰이 말씀해주신 빠르게 구현 + 클라이언트 편의성 방향 + 최적화에 관한 고민을 듣고 지금 당장 개선해야 하는 것은 아니지만, 
연관관계를 느슨한 결합으로 가져가는게 좋지 않을까? 하는 의견에서 pr 올려서 프린, 아톰과 함께 생각을 공유하고자 합니다 🙇🏽‍♂️

오랜만에 자바 코드를 작성하기도 하고, 위키 도메인 지식이 거의 없는 상태로 코드를 작성해서 허점이 많습니다. 참고해서 흐름만 봐주세요!