### PR TITLE
임시 재전송 로직에 주간 전송도 처리하도록 개선한다.

### DIFF
--- a/ddl.sql
+++ b/ddl.sql
@@ -3,7 +3,6 @@ create table question
     id               bigint auto_increment,
     content          text                        not null,
     title            varchar(255)                not null,
-    customized_title varchar(255),
     category         enum ('BACKEND','FRONTEND') not null,
     created_at       timestamp(6),
     updated_at       timestamp(6),

--- a/maeil-mail/src/main/java/maeilmail/admin/AdminApi.java
+++ b/maeil-mail/src/main/java/maeilmail/admin/AdminApi.java
@@ -1,5 +1,6 @@
 package maeilmail.admin;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import maeilmail.question.QuestionQueryService;
 import maeilmail.question.QuestionSummary;
@@ -8,9 +9,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor

--- a/maeil-mail/src/main/java/maeilmail/admin/AdminQuestionService.java
+++ b/maeil-mail/src/main/java/maeilmail/admin/AdminQuestionService.java
@@ -1,12 +1,11 @@
 package maeilmail.admin;
 
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
@@ -3,23 +3,21 @@ package maeilmail.bulksend.schedule;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import maeilmail.bulksend.sender.QuestionSender;
-import maeilmail.bulksend.sender.SubscribeQuestionMessage;
-import maeilmail.bulksend.view.SubscribeQuestionView;
-import maeilmail.question.Question;
+import maeilmail.bulksend.schedule.helper.ResendDailyHelper;
+import maeilmail.bulksend.schedule.helper.ResendWeeklyHelper;
 import maeilmail.subscribe.command.domain.Subscribe;
-import maeilmail.subscribe.command.domain.SubscribeFrequency;
 import maeilmail.subscribe.command.domain.SubscribeQuestion;
 import maeilmail.subscribe.command.domain.SubscribeQuestionRepository;
 import maeilmail.support.DistributedSupport;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-// TODO: 간헐적으로 메일 전송이 실패하는 현상을 해결하기 이전까지 임시로 사용합니다. (데일리 전송 전용)
+// TODO: 간헐적으로 메일 전송이 실패하는 현상을 해결하기 이전까지 임시로 사용합니다.
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -27,34 +25,23 @@ class ResendQuestionScheduler {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
-    private final QuestionSender questionSender;
-    private final SubscribeQuestionView subscribeQuestionView;
     private final DistributedSupport distributedSupport;
     private final SubscribeQuestionRepository subscribeQuestionRepository;
+    private final ResendDailyHelper resendDailyHelper;
+    private final ResendWeeklyHelper resendWeeklyHelper;
 
-    @Scheduled(cron = "0 25 7 * * MON-FRI", zone = "Asia/Seoul")
-    public void sendMail() {
-        log.info("임시 재전송 로직을 수행합니다. (일간)");
-        List<SubscribeQuestion> subscribeQuestions = getFailedSubscribeQuestions();
+    @Scheduled(cron = "0 3 23 * * *", zone = "Asia/Seoul")
+    public void resendMail() {
+        List<SubscribeQuestion> failed = getFailedSubscribeQuestions();
+        if (failed.isEmpty()) {
+            log.info("재전송 대상이 존재하지 않습니다.");
+            return;
+        }
 
-        List<SubscribeQuestion> filteredSubscribeQuestions = subscribeQuestions.stream()
-                .filter(this::isDaily)
-                .filter(it -> distributedSupport.isMine(it.getId()))
-                .toList();
-        log.info("{}명의 일간 구독자에게 질문지를 재전송합니다.", filteredSubscribeQuestions.size());
-
-        List<Long> removeTargetIds = filteredSubscribeQuestions.stream()
-                .map(SubscribeQuestion::getId)
-                .toList();
-        subscribeQuestionRepository.removeAllByIdIn(removeTargetIds);
-
-        filteredSubscribeQuestions.stream()
-                .map(this::generateQuestionMessage)
-                .forEach(questionSender::sendMail);
-    }
-
-    private boolean isDaily(SubscribeQuestion subscribeQuestion) {
-        return subscribeQuestion.getSubscribe().getFrequency() == SubscribeFrequency.DAILY;
+        log.info("임시 재전송 로직을 수행합니다. 총 {}건의 실패 질문지(subscribeQuestion)가 존재합니다.", failed.size());
+        Map<Long, List<SubscribeQuestion>> bundle = bundleQuestions(failed);
+        removeFailedData(bundle);
+        resendFailedMail(bundle);
     }
 
     private List<SubscribeQuestion> getFailedSubscribeQuestions() {
@@ -63,22 +50,50 @@ class ResendQuestionScheduler {
         return subscribeQuestionRepository.findAllFailedSubscribeQuestions(baseDate);
     }
 
-    private SubscribeQuestionMessage generateQuestionMessage(SubscribeQuestion subscribeQuestion) {
-        Subscribe subscribe = subscribeQuestion.getSubscribe();
-        Question question = subscribeQuestion.getQuestion();
-        String subject = question.getTitle();
-        String text = createText(subscribe, question);
-
-        return new SubscribeQuestionMessage(subscribe, question, subject, text);
+    /**
+     * 특정 subscribe의 질문지 맵(list 사이즈가 1인 경우 daily, 5인 경우 weekly)
+     * 7시 0분에 전송 실패했지만, 추후에 재전송합니다. 이 기간 동안 구독자가 전송 주기를 변경하는 예외 케이스를 대응합니다
+     */
+    private Map<Long, List<SubscribeQuestion>> bundleQuestions(List<SubscribeQuestion> failed) {
+        return failed.stream()
+                .filter(this::isMine)
+                .collect(Collectors.groupingBy(it -> it.getSubscribe().getId()));
     }
 
-    private String createText(Subscribe subscribe, Question question) {
-        HashMap<Object, Object> attribute = new HashMap<>();
-        attribute.put("questionId", question.getId());
-        attribute.put("question", question.getTitle());
-        attribute.put("email", subscribe.getEmail());
-        attribute.put("token", subscribe.getToken());
+    private boolean isMine(SubscribeQuestion subscribeQuestion) {
+        Subscribe subscribe = subscribeQuestion.getSubscribe();
 
-        return subscribeQuestionView.render(attribute);
+        return distributedSupport.isMine(subscribe.getId());
+    }
+
+    private void removeFailedData(Map<Long, List<SubscribeQuestion>> bundle) {
+        List<Long> removeTargetIds = bundle.values().stream()
+                .flatMap(List::stream)
+                .map(SubscribeQuestion::getId)
+                .toList();
+
+        subscribeQuestionRepository.removeAllByIdIn(removeTargetIds);
+    }
+
+    private void resendFailedMail(Map<Long, List<SubscribeQuestion>> bundle) {
+        List<SubscribeQuestion> dailyTargets = extractDailyResendTargets(bundle);
+        List<List<SubscribeQuestion>> weeklyTargets = extractWeeklyResendTargets(bundle);
+
+        log.info("{}명의 일간 구독자와 {}명의 주간 구독자에게 질문지를 재전송합니다.", dailyTargets.size(), weeklyTargets.size());
+        resendDailyHelper.resend(dailyTargets);
+        resendWeeklyHelper.resend(weeklyTargets);
+    }
+
+    private List<SubscribeQuestion> extractDailyResendTargets(Map<Long, List<SubscribeQuestion>> bundle) {
+        return bundle.values().stream()
+                .filter(subscribeQuestions -> subscribeQuestions.size() == 1)
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    private List<List<SubscribeQuestion>> extractWeeklyResendTargets(Map<Long, List<SubscribeQuestion>> bundle) {
+        return bundle.values().stream()
+                .filter(subscribeQuestions -> subscribeQuestions.size() == 5)
+                .toList();
     }
 }

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
@@ -53,8 +53,8 @@ class ResendQuestionScheduler {
                 .forEach(questionSender::sendMail);
     }
 
-    private boolean isDaily(SubscribeQuestion it) {
-        return it.getSubscribe().getFrequency() == SubscribeFrequency.DAILY;
+    private boolean isDaily(SubscribeQuestion subscribeQuestion) {
+        return subscribeQuestion.getSubscribe().getFrequency() == SubscribeFrequency.DAILY;
     }
 
     private List<SubscribeQuestion> getFailedSubscribeQuestions() {

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
@@ -12,6 +12,7 @@ import maeilmail.bulksend.sender.SubscribeQuestionMessage;
 import maeilmail.bulksend.view.SubscribeQuestionView;
 import maeilmail.question.Question;
 import maeilmail.subscribe.command.domain.Subscribe;
+import maeilmail.subscribe.command.domain.SubscribeFrequency;
 import maeilmail.subscribe.command.domain.SubscribeQuestion;
 import maeilmail.subscribe.command.domain.SubscribeQuestionRepository;
 import maeilmail.support.DistributedSupport;
@@ -38,6 +39,7 @@ class ResendQuestionScheduler {
         log.info("{}명의 일간 구독자에게 질문지를 재전송합니다.", subscribeQuestions.size());
 
         List<SubscribeQuestion> filteredSubscribeQuestions = subscribeQuestions.stream()
+                .filter(it -> it.getSubscribe().getFrequency() == SubscribeFrequency.DAILY)
                 .filter(it -> distributedSupport.isMine(it.getId()))
                 .toList();
 

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
@@ -38,7 +38,7 @@ class ResendQuestionScheduler {
         List<SubscribeQuestion> subscribeQuestions = getFailedSubscribeQuestions();
 
         List<SubscribeQuestion> filteredSubscribeQuestions = subscribeQuestions.stream()
-                .filter(it -> it.getSubscribe().getFrequency() == SubscribeFrequency.DAILY)
+                .filter(this::isDaily)
                 .filter(it -> distributedSupport.isMine(it.getId()))
                 .toList();
         log.info("{}명의 일간 구독자에게 질문지를 재전송합니다.", filteredSubscribeQuestions.size());
@@ -51,6 +51,10 @@ class ResendQuestionScheduler {
         filteredSubscribeQuestions.stream()
                 .map(this::generateQuestionMessage)
                 .forEach(questionSender::sendMail);
+    }
+
+    private boolean isDaily(SubscribeQuestion it) {
+        return it.getSubscribe().getFrequency() == SubscribeFrequency.DAILY;
     }
 
     private List<SubscribeQuestion> getFailedSubscribeQuestions() {

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
@@ -30,7 +30,7 @@ class ResendQuestionScheduler {
     private final ResendDailyHelper resendDailyHelper;
     private final ResendWeeklyHelper resendWeeklyHelper;
 
-    @Scheduled(cron = "0 3 23 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 25 7 * * MON-FRI", zone = "Asia/Seoul")
     public void resendMail() {
         List<SubscribeQuestion> failed = getFailedSubscribeQuestions();
         if (failed.isEmpty()) {

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/ResendQuestionScheduler.java
@@ -34,14 +34,14 @@ class ResendQuestionScheduler {
 
     @Scheduled(cron = "0 25 7 * * MON-FRI", zone = "Asia/Seoul")
     public void sendMail() {
-        log.info("임시 재전송 로직을 수행합니다.");
+        log.info("임시 재전송 로직을 수행합니다. (일간)");
         List<SubscribeQuestion> subscribeQuestions = getFailedSubscribeQuestions();
-        log.info("{}명의 일간 구독자에게 질문지를 재전송합니다.", subscribeQuestions.size());
 
         List<SubscribeQuestion> filteredSubscribeQuestions = subscribeQuestions.stream()
                 .filter(it -> it.getSubscribe().getFrequency() == SubscribeFrequency.DAILY)
                 .filter(it -> distributedSupport.isMine(it.getId()))
                 .toList();
+        log.info("{}명의 일간 구독자에게 질문지를 재전송합니다.", filteredSubscribeQuestions.size());
 
         List<Long> removeTargetIds = filteredSubscribeQuestions.stream()
                 .map(SubscribeQuestion::getId)

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/SendWeeklyQuestionScheduler.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/SendWeeklyQuestionScheduler.java
@@ -80,7 +80,7 @@ public class SendWeeklyQuestionScheduler {
         return questions.subList(fromIndex, fromIndex + WEEKLY_MAIL_SEND_COUNT);
     }
 
-    private String createText(Subscribe subscribe, List<QuestionSummary> questions) {
+    public String createText(Subscribe subscribe, List<QuestionSummary> questions) {
         LocalDate today = LocalDate.now();
         HashMap<Object, Object> attribute = new HashMap<>();
         String category = subscribe.getCategory().getDescription();
@@ -97,7 +97,7 @@ public class SendWeeklyQuestionScheduler {
         return weeklySubscribeQuestionView.render(attribute);
     }
 
-    private WeeklySubscribeQuestionMessage createWeeklySubscribeQuestionMessage(
+    public WeeklySubscribeQuestionMessage createWeeklySubscribeQuestionMessage(
             Subscribe subscribe,
             List<QuestionSummary> summaries,
             String subject,

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/helper/ResendDailyHelper.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/helper/ResendDailyHelper.java
@@ -1,0 +1,45 @@
+package maeilmail.bulksend.schedule.helper;
+
+import java.util.HashMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import maeilmail.bulksend.sender.QuestionSender;
+import maeilmail.bulksend.sender.SubscribeQuestionMessage;
+import maeilmail.bulksend.view.SubscribeQuestionView;
+import maeilmail.question.Question;
+import maeilmail.subscribe.command.domain.Subscribe;
+import maeilmail.subscribe.command.domain.SubscribeQuestion;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResendDailyHelper {
+
+    private final SubscribeQuestionView subscribeQuestionView;
+    private final QuestionSender questionSender;
+
+    public void resend(List<SubscribeQuestion> dailyTargets) {
+        dailyTargets.stream()
+                .map(this::generateQuestionMessage)
+                .forEach(questionSender::sendMail);
+    }
+
+    private SubscribeQuestionMessage generateQuestionMessage(SubscribeQuestion subscribeQuestion) {
+        Subscribe subscribe = subscribeQuestion.getSubscribe();
+        Question question = subscribeQuestion.getQuestion();
+        String subject = question.getTitle();
+        String text = createText(subscribe, question);
+
+        return new SubscribeQuestionMessage(subscribe, question, subject, text);
+    }
+
+    private String createText(Subscribe subscribe, Question question) {
+        HashMap<Object, Object> attribute = new HashMap<>();
+        attribute.put("questionId", question.getId());
+        attribute.put("question", question.getTitle());
+        attribute.put("email", subscribe.getEmail());
+        attribute.put("token", subscribe.getToken());
+
+        return subscribeQuestionView.render(attribute);
+    }
+}

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/helper/ResendWeeklyHelper.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/helper/ResendWeeklyHelper.java
@@ -1,0 +1,88 @@
+package maeilmail.bulksend.schedule.helper;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import maeilmail.bulksend.sender.WeeklyQuestionSender;
+import maeilmail.bulksend.sender.WeeklySubscribeQuestionMessage;
+import maeilmail.bulksend.view.WeeklySubscribeQuestionView;
+import maeilmail.question.Question;
+import maeilmail.question.QuestionSummary;
+import maeilmail.subscribe.command.domain.Subscribe;
+import maeilmail.subscribe.command.domain.SubscribeQuestion;
+import maeilsupport.DateUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResendWeeklyHelper {
+
+    private final WeeklySubscribeQuestionView weeklySubscribeQuestionView;
+    private final WeeklyQuestionSender weeklyQuestionSender;
+
+    public void resend(List<List<SubscribeQuestion>> weeklyTargets) {
+        weeklyTargets.stream()
+                .map(this::generateWeeklyQuestionMessage)
+                .filter(Objects::nonNull)
+                .forEach(weeklyQuestionSender::sendMail);
+    }
+
+    private WeeklySubscribeQuestionMessage generateWeeklyQuestionMessage(List<SubscribeQuestion> subscribeQuestions) {
+        if (subscribeQuestions.size() != 5) {
+            return null;
+        }
+
+        String subject = "이번주 면접 질문을 보내드려요.";
+        Subscribe subscribe = subscribeQuestions.get(0).getSubscribe();
+        List<QuestionSummary> questions = subscribeQuestions.stream()
+                .map(SubscribeQuestion::getQuestion)
+                .map(this::toQuestionSummary)
+                .sorted((o1, o2) -> Math.toIntExact(o1.id() - o2.id()))
+                .toList();
+
+        return createWeeklySubscribeQuestionMessage(subscribe, questions, subject, createText(subscribe, questions));
+    }
+
+    private QuestionSummary toQuestionSummary(Question it) {
+        return new QuestionSummary(
+                it.getId(),
+                it.getTitle(),
+                it.getContent(),
+                it.getCategory().toLowerCase(),
+                it.getCreatedAt(),
+                it.getUpdatedAt()
+        );
+    }
+
+    private String createText(Subscribe subscribe, List<QuestionSummary> questions) {
+        LocalDate today = LocalDate.now();
+        HashMap<Object, Object> attribute = new HashMap<>();
+        String category = subscribe.getCategory().getDescription();
+        int weekOfMonth = DateUtils.getWeekOfMonth(today);
+        attribute.put("questions", questions);
+        attribute.put("category", subscribe.getCategory().toLowerCase());
+        attribute.put("email", subscribe.getEmail());
+        attribute.put("token", subscribe.getToken());
+        attribute.put("weekLabel", category + " " + today.getMonthValue() + "월 " + weekOfMonth + "주차 질문");
+        attribute.put("year", today.getYear());
+        attribute.put("month", today.getMonthValue());
+        attribute.put("week", weekOfMonth);
+
+        return weeklySubscribeQuestionView.render(attribute);
+    }
+
+    private WeeklySubscribeQuestionMessage createWeeklySubscribeQuestionMessage(
+            Subscribe subscribe,
+            List<QuestionSummary> summaries,
+            String subject,
+            String text
+    ) {
+        List<Question> questions = summaries.stream()
+                .map(QuestionSummary::toQuestion)
+                .toList();
+
+        return new WeeklySubscribeQuestionMessage(subscribe, questions, subject, text);
+    }
+}

--- a/maeil-mail/src/main/java/maeilmail/bulksend/schedule/helper/ResendWeeklyHelper.java
+++ b/maeil-mail/src/main/java/maeilmail/bulksend/schedule/helper/ResendWeeklyHelper.java
@@ -1,26 +1,23 @@
 package maeilmail.bulksend.schedule.helper;
 
-import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import maeilmail.bulksend.schedule.SendWeeklyQuestionScheduler;
 import maeilmail.bulksend.sender.WeeklyQuestionSender;
 import maeilmail.bulksend.sender.WeeklySubscribeQuestionMessage;
-import maeilmail.bulksend.view.WeeklySubscribeQuestionView;
 import maeilmail.question.Question;
 import maeilmail.question.QuestionSummary;
 import maeilmail.subscribe.command.domain.Subscribe;
 import maeilmail.subscribe.command.domain.SubscribeQuestion;
-import maeilsupport.DateUtils;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class ResendWeeklyHelper {
 
-    private final WeeklySubscribeQuestionView weeklySubscribeQuestionView;
     private final WeeklyQuestionSender weeklyQuestionSender;
+    private final SendWeeklyQuestionScheduler sendWeeklyQuestionScheduler;
 
     public void resend(List<List<SubscribeQuestion>> weeklyTargets) {
         weeklyTargets.stream()
@@ -42,7 +39,9 @@ public class ResendWeeklyHelper {
                 .sorted((o1, o2) -> Math.toIntExact(o1.id() - o2.id()))
                 .toList();
 
-        return createWeeklySubscribeQuestionMessage(subscribe, questions, subject, createText(subscribe, questions));
+        String text = sendWeeklyQuestionScheduler.createText(subscribe, questions);
+
+        return sendWeeklyQuestionScheduler.createWeeklySubscribeQuestionMessage(subscribe, questions, subject, text);
     }
 
     private QuestionSummary toQuestionSummary(Question it) {
@@ -54,35 +53,5 @@ public class ResendWeeklyHelper {
                 it.getCreatedAt(),
                 it.getUpdatedAt()
         );
-    }
-
-    private String createText(Subscribe subscribe, List<QuestionSummary> questions) {
-        LocalDate today = LocalDate.now();
-        HashMap<Object, Object> attribute = new HashMap<>();
-        String category = subscribe.getCategory().getDescription();
-        int weekOfMonth = DateUtils.getWeekOfMonth(today);
-        attribute.put("questions", questions);
-        attribute.put("category", subscribe.getCategory().toLowerCase());
-        attribute.put("email", subscribe.getEmail());
-        attribute.put("token", subscribe.getToken());
-        attribute.put("weekLabel", category + " " + today.getMonthValue() + "월 " + weekOfMonth + "주차 질문");
-        attribute.put("year", today.getYear());
-        attribute.put("month", today.getMonthValue());
-        attribute.put("week", weekOfMonth);
-
-        return weeklySubscribeQuestionView.render(attribute);
-    }
-
-    private WeeklySubscribeQuestionMessage createWeeklySubscribeQuestionMessage(
-            Subscribe subscribe,
-            List<QuestionSummary> summaries,
-            String subject,
-            String text
-    ) {
-        List<Question> questions = summaries.stream()
-                .map(QuestionSummary::toQuestion)
-                .toList();
-
-        return new WeeklySubscribeQuestionMessage(subscribe, questions, subject, text);
     }
 }

--- a/maeil-mail/src/main/java/maeilmail/question/Question.java
+++ b/maeil-mail/src/main/java/maeilmail/question/Question.java
@@ -1,7 +1,18 @@
 package maeilmail.question;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import maeilsupport.BaseEntity;
 
 @Entity

--- a/maeil-mail/src/main/java/maeilmail/question/QuestionQueryService.java
+++ b/maeil-mail/src/main/java/maeilmail/question/QuestionQueryService.java
@@ -1,5 +1,9 @@
 package maeilmail.question;
 
+import static maeilmail.question.QQuestion.question;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -12,11 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.NoSuchElementException;
-
-import static maeilmail.question.QQuestion.question;
 
 @Slf4j
 @Service

--- a/maeil-mail/src/main/java/maeilmail/question/QuestionSummary.java
+++ b/maeil-mail/src/main/java/maeilmail/question/QuestionSummary.java
@@ -1,8 +1,7 @@
 package maeilmail.question;
 
-import com.querydsl.core.annotations.QueryProjection;
-
 import java.time.LocalDateTime;
+import com.querydsl.core.annotations.QueryProjection;
 
 public record QuestionSummary(
         Long id,

--- a/maeil-mail/src/test/java/maeilmail/admin/AdminApiTest.java
+++ b/maeil-mail/src/test/java/maeilmail/admin/AdminApiTest.java
@@ -1,5 +1,16 @@
 package maeilmail.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
 import maeilmail.question.QuestionSummary;
 import maeilmail.support.ApiTestSupport;
 import maeilsupport.PaginationResponse;
@@ -8,16 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
-
-import java.util.Collections;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class AdminApiTest extends ApiTestSupport {
 

--- a/maeil-mail/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
+++ b/maeil-mail/src/test/java/maeilmail/question/QuestionQueryServiceTest.java
@@ -1,20 +1,19 @@
 package maeilmail.question;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
 import maeilmail.support.IntegrationTestSupport;
 import maeilsupport.PaginationResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.NoSuchElementException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 class QuestionQueryServiceTest extends IntegrationTestSupport {
 


### PR DESCRIPTION
- close #257 
- 임시 재전송 로직에 주간 전송도 처리할 수 있도록 개선했습니다.
- 7시에 전송한 이후에, 25분에 재전송을 수행하는데 그 사이에 전송 주기를 변경하는 경우를 대응하기 어려워 Map 자료 구조를 사용해 그룹 연산을 수행했습니다.