### PR TITLE
매일위키 객관식 문제 출제 기능을 구현한다.

### DIFF
--- a/maeil-wiki/src/main/java/maeilwiki/wiki/api/MultipleChoiceWikiApi.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/api/MultipleChoiceWikiApi.java
@@ -1,0 +1,59 @@
+package maeilwiki.wiki.api;
+
+import lombok.RequiredArgsConstructor;
+import maeilsupport.PaginationResponse;
+import maeilwiki.member.api.NotRequiredIdentity;
+import maeilwiki.member.application.MemberIdentity;
+import maeilwiki.wiki.application.MultipleChoiceWikiRequest;
+import maeilwiki.wiki.application.MultipleChoiceWikiResponse;
+import maeilwiki.wiki.application.MultipleChoiceWikiService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+class MultipleChoiceWikiApi {
+
+    private final MultipleChoiceWikiService multipleChoiceWikiService;
+
+    @PostMapping("/wiki/multiple-choice")
+    public ResponseEntity<Void> createWiki(MemberIdentity identity, @RequestBody MultipleChoiceWikiRequest request) {
+        Long resourceId = multipleChoiceWikiService.create(identity, request);
+        URI location = URI.create(resourceId.toString());
+
+        return ResponseEntity.created(location).build();
+    }
+
+    @DeleteMapping("/wiki/multiple-choice/{id}")
+    public ResponseEntity<Void> deleteWiki(MemberIdentity identity, @PathVariable Long id) {
+        multipleChoiceWikiService.remove(identity, id);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/wiki/multiple-choice/{id}")
+    public ResponseEntity<MultipleChoiceWikiResponse> getWiki(@NotRequiredIdentity MemberIdentity identity, @PathVariable Long id) {
+        MultipleChoiceWikiResponse wiki = multipleChoiceWikiService.getWikiById(identity, id);
+
+        return ResponseEntity.ok(wiki);
+    }
+
+    @GetMapping("/wiki/multiple-choice")
+    public ResponseEntity<PaginationResponse<MultipleChoiceWikiResponse>> getWikis(
+            @RequestParam(defaultValue = "all") String category,
+            @PageableDefault Pageable pageable
+    ) {
+        PaginationResponse<MultipleChoiceWikiResponse> response = multipleChoiceWikiService.pageByCategory(category, pageable);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/application/MultipleChoiceWikiRequest.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/application/MultipleChoiceWikiRequest.java
@@ -1,0 +1,32 @@
+package maeilwiki.wiki.application;
+
+import maeilwiki.wiki.domain.MultipleChoiceQuestion;
+import maeilwiki.wiki.domain.MultipleChoiceWiki;
+import java.util.List;
+
+public record MultipleChoiceWikiRequest(
+        String title,
+        String content,
+        String category,
+        boolean isAnonymous,
+        int difficultyLevel,
+        List<MultipleChoiceQuestionRequest> multipleChoiceQuestions,
+        Long memberId
+) {
+
+    public MultipleChoiceWiki toMultipleChoiceWiki(Long memberId) {
+        List<MultipleChoiceQuestion> questions = multipleChoiceQuestions.stream().map(MultipleChoiceQuestionRequest::toMultipleQuestion).toList();
+
+        if (content == null || content.isBlank()) {
+            return new MultipleChoiceWiki(title, "", category, isAnonymous, difficultyLevel, questions, memberId);
+        }
+
+        return new MultipleChoiceWiki(title, content, category, isAnonymous, difficultyLevel, questions, memberId);
+    }
+
+    record MultipleChoiceQuestionRequest(String content, boolean isAnswer) {
+        MultipleChoiceQuestion toMultipleQuestion() {
+            return new MultipleChoiceQuestion(content, isAnswer);
+        }
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/application/MultipleChoiceWikiResponse.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/application/MultipleChoiceWikiResponse.java
@@ -1,0 +1,54 @@
+package maeilwiki.wiki.application;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import maeilwiki.member.domain.Member;
+import maeilwiki.member.dto.MemberThumbnail;
+import maeilwiki.wiki.domain.MultipleChoiceWiki;
+import maeilwiki.wiki.dto.MultipleChoiceWikiSummary;
+import java.time.LocalDateTime;
+import java.util.List;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+public record MultipleChoiceWikiResponse(
+        Long id,
+        String title,
+        @JsonInclude(Include.NON_NULL) String content,
+        String category,
+        boolean isAnonymous,
+        int difficultyLevel,
+        List<MultipleChoiceQuestionResponse> multipleChoiceQuestions,
+        LocalDateTime createdAt,
+        MemberThumbnail owner
+) {
+
+    public static MultipleChoiceWikiResponse of(MultipleChoiceWiki wiki, Member member) {
+        return new MultipleChoiceWikiResponse(
+                wiki.getId(),
+                wiki.getTitle(),
+                wiki.getDetail(),
+                wiki.getCategory().name(),
+                wiki.isAnonymous(),
+                wiki.getDifficultyLevel(),
+                wiki.getMultipleChoiceQuestions().stream().map(it -> new MultipleChoiceQuestionResponse(it.getContent(), it.isAnswer())).toList(),
+                wiki.getCreatedAt(),
+                new MemberThumbnail(member.getId(), member.getName(), member.getProfileImageUrl(), member.getGithubUrl())
+        );
+    }
+
+    public static MultipleChoiceWikiResponse of(MultipleChoiceWikiSummary summary) {
+        return new MultipleChoiceWikiResponse(
+                summary.id(),
+                summary.title(),
+                summary.detail(),
+                summary.category(),
+                summary.isAnonymous(),
+                summary.difficultyLevel(),
+                summary.multipleChoiceQuestions().stream().map(it -> new MultipleChoiceQuestionResponse(it.getContent(), it.isAnswer())).toList(),
+                summary.createdAt(),
+                summary.owner()
+        );
+    }
+
+    record MultipleChoiceQuestionResponse(String content, boolean isAnswer) {
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/application/MultipleChoiceWikiService.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/application/MultipleChoiceWikiService.java
@@ -1,0 +1,63 @@
+package maeilwiki.wiki.application;
+
+import lombok.RequiredArgsConstructor;
+import maeilsupport.PaginationResponse;
+import maeilwiki.member.application.MemberIdentity;
+import maeilwiki.member.application.MemberService;
+import maeilwiki.member.domain.Member;
+import maeilwiki.wiki.domain.MultipleChoiceWiki;
+import maeilwiki.wiki.domain.MultipleChoiceWikiRepository;
+import maeilwiki.wiki.dto.MultipleChoiceWikiSummary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class MultipleChoiceWikiService {
+
+    private final MultipleChoiceWikiRepository multipleChoiceWikiRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public Long create(MemberIdentity identity, MultipleChoiceWikiRequest request) {
+        Member member = memberService.findById(identity.id());
+        MultipleChoiceWiki multipleChoiceWiki = request.toMultipleChoiceWiki(member.getId());
+
+        return multipleChoiceWikiRepository.save(multipleChoiceWiki).getId();
+    }
+
+    @Transactional
+    public void remove(MemberIdentity identity, Long wikiId) {
+        MultipleChoiceWiki multipleChoiceWiki = multipleChoiceWikiRepository.findById(wikiId)
+                .orElseThrow(NoSuchElementException::new);
+        validateOwner(identity, multipleChoiceWiki);
+
+        multipleChoiceWiki.remove();
+    }
+
+    private void validateOwner(MemberIdentity identity, MultipleChoiceWiki multipleChoiceWiki) {
+        if (!identity.canAccessToResource(multipleChoiceWiki.getMemberId())) {
+            throw new IllegalStateException("자신의 위키만 삭제할 수 있습니다.");
+        }
+    }
+
+    public MultipleChoiceWikiResponse getWikiById(MemberIdentity identity, Long id) {
+        MultipleChoiceWiki multipleChoiceWiki = multipleChoiceWikiRepository.findById(id).orElseThrow(NoSuchElementException::new);
+        Member member = memberService.findById(multipleChoiceWiki.getMemberId());
+        return MultipleChoiceWikiResponse.of(multipleChoiceWiki, member);
+    }
+
+    public PaginationResponse<MultipleChoiceWikiResponse> pageByCategory(String category, Pageable pageable) {
+        Page<MultipleChoiceWikiSummary> pageResults = multipleChoiceWikiRepository.pageByCategory(category, pageable);
+        List<MultipleChoiceWikiResponse> wikiResponses = pageResults.getContent()
+                .stream()
+                .map(MultipleChoiceWikiResponse::of)
+                .toList();
+
+        return new PaginationResponse<>(pageResults.isLast(), (long) pageResults.getTotalPages(), wikiResponses);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceQuestion.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceQuestion.java
@@ -1,0 +1,43 @@
+package maeilwiki.wiki.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import maeilsupport.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MultipleChoiceQuestion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "detail", nullable = false)
+    private String content;
+
+    @Column(name = "isAnswer", nullable = false)
+    private boolean isAnswer;
+
+    @ManyToOne
+    @JoinColumn(name = "multiple_choice_wiki_id")
+    private MultipleChoiceWiki multipleChoiceWiki;
+
+    public MultipleChoiceQuestion(String content, boolean isAnswer) {
+        this.content = content;
+        this.isAnswer = isAnswer;
+    }
+
+    public MultipleChoiceQuestion applyMultipleChoiceWiki(MultipleChoiceWiki multipleChoiceWiki) {
+        this.multipleChoiceWiki = multipleChoiceWiki;
+        return this;
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWiki.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWiki.java
@@ -1,0 +1,114 @@
+package maeilwiki.wiki.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import maeilsupport.BaseEntity;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MultipleChoiceWiki extends BaseEntity {
+
+    private static final int MAX_TITLE_LENGTH = 255;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = MAX_TITLE_LENGTH)
+    private String title;
+
+    @Column(name = "detail", columnDefinition = "TEXT")
+    private String detail;
+
+    @Column(name = "wiki_category", nullable = false, columnDefinition = "VARCHAR(10)")
+    @Enumerated(value = EnumType.STRING)
+    private WikiCategory category;
+
+    @Column(name = "is_anonymous", nullable = false)
+    private boolean isAnonymous;
+
+    @Column(name = "difficulty_level", nullable = false)
+    private Integer difficultyLevel;
+
+    @OneToMany(mappedBy = "multipleChoiceWiki", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<MultipleChoiceQuestion> multipleChoiceQuestions = new ArrayList<>();
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    public MultipleChoiceWiki(String title, String category, boolean isAnonymous, int difficultyLevel, List<MultipleChoiceQuestion> multipleChoiceQuestions, Long memberId) {
+        this(title, "", category, isAnonymous, difficultyLevel, multipleChoiceQuestions, memberId);
+    }
+
+    public MultipleChoiceWiki(String title, String detail, String category, boolean isAnonymous, int difficultyLevel, List<MultipleChoiceQuestion> multipleChoiceQuestions, Long memberId) {
+        validateTitle(title);
+        validateDifficultyLevel(difficultyLevel);
+        validateMultipleChoiceQuestions(multipleChoiceQuestions);
+        validateMember(memberId);
+        this.title = title;
+        this.detail = detail;
+        this.category = WikiCategory.from(category);
+        this.isAnonymous = isAnonymous;
+        this.difficultyLevel = difficultyLevel;
+        this.multipleChoiceQuestions = multipleChoiceQuestions.stream().map(it -> it.applyMultipleChoiceWiki(this)).toList();
+        this.memberId = memberId;
+    }
+
+    private void validateMember(Long memberId) {
+        if (memberId == null || memberId == 0) {
+            throw new IllegalArgumentException("작성 회원은 비어있을 수 없습니다.");
+        }
+    }
+
+    private void validateMultipleChoiceQuestions(List<MultipleChoiceQuestion> multipleChoiceQuestions) {
+        if (multipleChoiceQuestions == null || multipleChoiceQuestions.isEmpty()) {
+            throw new IllegalArgumentException("객관식 문제는 최소 1개 이상 존재해야 합니다.");
+        }
+
+        if (multipleChoiceQuestions.size() > 10) {
+            throw new IllegalArgumentException("객관식 문제는 최대 10개까지 등록할 수 있습니다.");
+        }
+    }
+
+    private void validateDifficultyLevel(int difficultyLevel) {
+        if (difficultyLevel < 1 || difficultyLevel > 5) {
+            throw new IllegalArgumentException("난이도는 1~5 범위 이내로 설정해야 합니다.");
+        }
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("질문은 필수 입력값입니다.");
+        }
+
+        if (title.length() > MAX_TITLE_LENGTH) {
+            throw new IllegalArgumentException("질문은 %d자 이하여야 합니다.".formatted(MAX_TITLE_LENGTH));
+        }
+    }
+
+    public void remove() {
+        if (deletedAt != null) {
+            throw new IllegalStateException("이미 삭제된 위키입니다.");
+        }
+
+        deletedAt = LocalDateTime.now();
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWikiRepository.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWikiRepository.java
@@ -1,0 +1,6 @@
+package maeilwiki.wiki.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MultipleChoiceWikiRepository extends JpaRepository<MultipleChoiceWiki, Long>, MultipleChoiceWikiRepositoryCustom {
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWikiRepositoryCustom.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWikiRepositoryCustom.java
@@ -1,0 +1,13 @@
+package maeilwiki.wiki.domain;
+
+import maeilwiki.wiki.dto.MultipleChoiceWikiSummary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.Optional;
+
+public interface MultipleChoiceWikiRepositoryCustom {
+
+    Optional<MultipleChoiceWikiSummary> queryOneById(Long id);
+
+    Page<MultipleChoiceWikiSummary> pageByCategory(String category, Pageable pageable);
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWikiRepositoryImpl.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/domain/MultipleChoiceWikiRepositoryImpl.java
@@ -1,0 +1,85 @@
+package maeilwiki.wiki.domain;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import maeilwiki.member.dto.QMemberThumbnail;
+import maeilwiki.wiki.dto.MultipleChoiceWikiSummary;
+import maeilwiki.wiki.dto.QMultipleChoiceWikiSummary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+import static maeilwiki.comment.domain.QComment.comment;
+import static maeilwiki.member.domain.QMember.member;
+import static maeilwiki.wiki.domain.QMultipleChoiceWiki.multipleChoiceWiki;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+class MultipleChoiceWikiRepositoryImpl implements MultipleChoiceWikiRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MultipleChoiceWikiSummary> queryOneById(Long wikiId) {
+        MultipleChoiceWikiSummary wikiSummary = queryFactory.select(projectionMultipleChoiceWikiSummary())
+                .from(multipleChoiceWiki)
+                .join(member).on(multipleChoiceWiki.memberId.eq(member.id))
+                .where(multipleChoiceWiki.id.eq(wikiId)
+                        .and(isNotDeletedWiki()))
+                .fetchOne();
+        return Optional.ofNullable(wikiSummary);
+    }
+
+    @Override
+    public Page<MultipleChoiceWikiSummary> pageByCategory(String category, Pageable pageable) {
+        JPAQuery<Long> countQuery = queryFactory.select(multipleChoiceWiki.count())
+                .from(multipleChoiceWiki)
+                .where(isNotDeletedWiki()
+                        .and(eqCategory(category)));
+
+        JPAQuery<MultipleChoiceWikiSummary> resultQuery = queryFactory.select(projectionMultipleChoiceWikiSummary())
+                .from(multipleChoiceWiki)
+                .join(member).on(multipleChoiceWiki.memberId.eq(member.id))
+                .leftJoin(comment).on(multipleChoiceWiki.id.eq(comment.wikiId))
+                .where(isNotDeletedWiki().and(eqCategory(category)))
+                .groupBy(multipleChoiceWiki.id)
+                .orderBy(multipleChoiceWiki.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        return PageableExecutionUtils.getPage(resultQuery.fetch(), pageable, countQuery::fetchOne);
+    }
+
+    private QMultipleChoiceWikiSummary projectionMultipleChoiceWikiSummary() {
+        return new QMultipleChoiceWikiSummary(
+                multipleChoiceWiki.id,
+                multipleChoiceWiki.title,
+                multipleChoiceWiki.detail,
+                multipleChoiceWiki.category.stringValue().lower(),
+                multipleChoiceWiki.isAnonymous,
+                multipleChoiceWiki.difficultyLevel,
+                multipleChoiceWiki.multipleChoiceQuestions,
+                multipleChoiceWiki.createdAt,
+                projectionMemberThumbnail()
+        );
+    }
+
+    private BooleanExpression isNotDeletedWiki() {
+        return multipleChoiceWiki.deletedAt.isNull();
+    }
+
+    private BooleanExpression eqCategory(String category) {
+        if (category == null || category.equalsIgnoreCase("all")) {
+            return null;
+        }
+
+        return multipleChoiceWiki.category.eq(WikiCategory.from(category));
+    }
+
+    private QMemberThumbnail projectionMemberThumbnail() {
+        return new QMemberThumbnail(member.id, member.name, member.profileImageUrl, member.githubUrl);
+    }
+}

--- a/maeil-wiki/src/main/java/maeilwiki/wiki/dto/MultipleChoiceWikiSummary.java
+++ b/maeil-wiki/src/main/java/maeilwiki/wiki/dto/MultipleChoiceWikiSummary.java
@@ -1,0 +1,30 @@
+package maeilwiki.wiki.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import maeilwiki.member.dto.MemberThumbnail;
+import maeilwiki.wiki.domain.MultipleChoiceQuestion;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MultipleChoiceWikiSummary(
+        Long id,
+        String title,
+        String detail,
+        String category,
+        boolean isAnonymous,
+        int difficultyLevel,
+        List<MultipleChoiceQuestion> multipleChoiceQuestions,
+        LocalDateTime createdAt,
+        MemberThumbnail owner
+) {
+
+    @QueryProjection
+    public MultipleChoiceWikiSummary {
+    }
+
+    public MultipleChoiceWikiSummary toAnonymousOwner() {
+        MemberThumbnail anonymousOwner = new MemberThumbnail(owner.id(), null, null, null);
+
+        return new MultipleChoiceWikiSummary(id, title, detail, category, isAnonymous, difficultyLevel, multipleChoiceQuestions, createdAt, anonymousOwner);
+    }
+}


### PR DESCRIPTION
의사코드라고 생각하고 훑어봐주세요.
대략적인 엔티티 설계랑 주관식 코드 비슷하게 작성해봤습니다.