### PR TITLE
AdminAuthInterceptor의 예외 케이스별 테스트 코드를 작성한다.

### DIFF
--- a/mail-admin/src/test/java/maeilmail/admin/api/AdminApiTest.java
+++ b/mail-admin/src/test/java/maeilmail/admin/api/AdminApiTest.java
@@ -2,6 +2,7 @@ package maeilmail.admin.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,6 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Collections;
+
+import jakarta.servlet.ServletException;
 import maeilmail.PaginationResponse;
 import maeilmail.question.QuestionSummary;
 import maeilmail.support.ApiTestSupport;
@@ -51,5 +54,29 @@ class AdminApiTest extends ApiTestSupport {
                 () -> assertThat(actualPageable.getPageSize()).isEqualTo(10),
                 () -> assertThat(actualPageable.getPageNumber()).isEqualTo(0)
         );
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 인증에 실패한다.")
+    void authFailWhenNoAuthorizationHeader() throws Exception {
+        assertThrows(ServletException.class, () ->
+                mockMvc.perform(get("/admin/question"))
+                        .andDo(print()));
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더에 'Basic ' 접두사가 없으면 인증에 실패한다.")
+    void authFailWhenMissingBasicPrefix() throws Exception {
+        assertThrows(ServletException.class, () ->
+                mockMvc.perform(get("/admin/question"))
+                        .andDo(print()));
+    }
+
+    @Test
+    @DisplayName("잘못된 시크릿이면 인증에 실패한다.")
+    void authFailWhenWrongSecret() throws Exception {
+        assertThrows(ServletException.class, () ->
+                mockMvc.perform(get("/admin/question"))
+                        .andDo(print()));
     }
 }

--- a/mail-admin/src/test/java/maeilmail/admin/api/AdminApiTest.java
+++ b/mail-admin/src/test/java/maeilmail/admin/api/AdminApiTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -68,7 +69,7 @@ class AdminApiTest extends ApiTestSupport {
     @DisplayName("Authorization 헤더에 'Basic ' 접두사가 없으면 인증에 실패한다.")
     void authFailWhenMissingBasicPrefix() throws Exception {
         assertThrows(ServletException.class, () ->
-                mockMvc.perform(get("/admin/question"))
+                mockMvc.perform(get("/admin/question").header("Authorization", secret))
                         .andDo(print()));
     }
 
@@ -76,7 +77,15 @@ class AdminApiTest extends ApiTestSupport {
     @DisplayName("잘못된 시크릿이면 인증에 실패한다.")
     void authFailWhenWrongSecret() throws Exception {
         assertThrows(ServletException.class, () ->
-                mockMvc.perform(get("/admin/question"))
+                mockMvc.perform(get("/admin/question").header("Authorization", "Basic wrong-secret"))
                         .andDo(print()));
+    }
+
+    @Test
+    @DisplayName("OPTIONS preflight 요청은 인증 없이 통과한다.")
+    void preflightRequestPassesWithoutAuth() throws Exception {
+        mockMvc.perform(options("/admin/question"))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 }

--- a/mail-admin/src/test/java/maeilmail/support/AdminWebMvcConfig.java
+++ b/mail-admin/src/test/java/maeilmail/support/AdminWebMvcConfig.java
@@ -1,0 +1,20 @@
+package maeilmail.support;
+
+import maeilmail.admin.api.AdminAuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@TestConfiguration
+public class AdminWebMvcConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private AdminAuthInterceptor adminAuthInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminAuthInterceptor)
+                .addPathPatterns("/admin/**");
+    }
+}

--- a/mail-admin/src/test/java/maeilmail/support/ApiTestSupport.java
+++ b/mail-admin/src/test/java/maeilmail/support/ApiTestSupport.java
@@ -8,9 +8,11 @@ import maeilmail.question.QuestionQueryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {AdminApi.class})
+@Import(AdminWebMvcConfig.class)
 public abstract class ApiTestSupport {
 
     @Autowired


### PR DESCRIPTION
- close #307 